### PR TITLE
feat(pgext,search): add L2 (Euclidean) distance and <-> operator (#19)

### DIFF
--- a/pgext/sql/tqvector--0.1.0.sql
+++ b/pgext/sql/tqvector--0.1.0.sql
@@ -27,6 +27,12 @@ AS '$libdir/tqvector', 'tq_cosine_sim_wrapper' LANGUAGE C IMMUTABLE STRICT PARAL
 CREATE FUNCTION tq_cosine_dist(tqvector, tqvector) RETURNS float4
 AS '$libdir/tqvector', 'tq_cosine_dist_wrapper' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tq_l2_distance(tqvector, tqvector) RETURNS float4
+AS '$libdir/tqvector', 'tq_l2_distance_wrapper' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION tq_l2_distance_squared(tqvector, tqvector) RETURNS float4
+AS '$libdir/tqvector', 'tq_l2_distance_squared_wrapper' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION tq_dim(tqvector) RETURNS int
 AS '$libdir/tqvector', 'tq_dim_wrapper' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
@@ -51,4 +57,9 @@ COMMENT ON FUNCTION tq_bulk_compress(text, text, text, int, int) IS
 CREATE OPERATOR <=> (
     LEFTARG = tqvector, RIGHTARG = tqvector,
     FUNCTION = tq_cosine_dist, COMMUTATOR = <=>
+);
+
+CREATE OPERATOR <-> (
+    LEFTARG = tqvector, RIGHTARG = tqvector,
+    FUNCTION = tq_l2_distance, COMMUTATOR = <->
 );

--- a/pgext/src/lib.rs
+++ b/pgext/src/lib.rs
@@ -15,6 +15,10 @@
 //! -- Search with cosine distance
 //! SELECT id, tqv <=> query_tqv AS dist
 //! FROM chunks_tq ORDER BY dist LIMIT 10;
+//!
+//! -- Search with L2 (Euclidean) distance
+//! SELECT id, tqv <-> query_tqv AS dist
+//! FROM chunks_tq ORDER BY dist LIMIT 10;
 //! ```
 //!
 //! Copyright (c) 2026 Andrew H. Bond. MIT License.
@@ -70,6 +74,35 @@ fn tq_cosine_sim(a: TqVector, b: TqVector) -> f32 {
 #[pg_extern(immutable, parallel_safe)]
 fn tq_cosine_dist(a: TqVector, b: TqVector) -> f32 {
     1.0 - tq_cosine_sim(a, b)
+}
+
+/// Squared L2 (Euclidean) distance between two compressed vectors.
+///
+/// Returns ``sum_d (a[d] - b[d])^2`` after decompression. Skips the
+/// final ``sqrt`` — for ORDER BY ranking the result is monotone with
+/// the true L2 distance, so this is faster when the absolute distance
+/// is not needed.
+#[pg_extern(immutable, parallel_safe)]
+fn tq_l2_distance_squared(a: TqVector, b: TqVector) -> f32 {
+    if a.dim != b.dim {
+        pgrx::error!("dimension mismatch: {} vs {}", a.dim, b.dim);
+    }
+    let va = compress::decompress(&a);
+    let vb = compress::decompress(&b);
+
+    va.iter()
+        .zip(vb.iter())
+        .map(|(x, y)| {
+            let d = x - y;
+            d * d
+        })
+        .sum()
+}
+
+/// L2 (Euclidean) distance between two compressed vectors.
+#[pg_extern(immutable, parallel_safe)]
+fn tq_l2_distance(a: TqVector, b: TqVector) -> f32 {
+    tq_l2_distance_squared(a, b).sqrt()
 }
 
 // ─── Metadata functions ──────────────────────────────────────────
@@ -228,6 +261,16 @@ CREATE OPERATOR <=> (
 
 COMMENT ON OPERATOR <=> (tqvector, tqvector) IS
     'TurboQuant cosine distance (1 - cosine_similarity)';
+
+CREATE OPERATOR <-> (
+    LEFTARG = tqvector,
+    RIGHTARG = tqvector,
+    FUNCTION = tq_l2_distance,
+    COMMUTATOR = <->
+);
+
+COMMENT ON OPERATOR <-> (tqvector, tqvector) IS
+    'TurboQuant L2 (Euclidean) distance';
 "#,
-    name = "tqvector_cosine_dist_operator",
+    name = "tqvector_distance_operators",
 );

--- a/tests/test_cuda_search.py
+++ b/tests/test_cuda_search.py
@@ -98,3 +98,69 @@ class TestGPUADCSearch:
         assert len(top_idx) == 10
         # Self should be in top results (not necessarily #1 due to quantization)
         assert 0 in top_idx[:5], f"Self not in top-5: {top_idx}"
+
+
+@pytest.mark.skipif(not HAS_CUPY, reason="CuPy not available")
+class TestGPUL2Search:
+    def test_self_is_nearest(self) -> None:
+        from turboquant_pro import TurboQuantPGVector
+        from turboquant_pro.cuda_search import gpu_l2_search
+
+        rng = np.random.default_rng(42)
+        dim = 384
+        n = 500
+        corpus = rng.standard_normal((n, dim)).astype(np.float32)
+
+        tq = TurboQuantPGVector(dim=dim, bits=3, seed=42)
+        compressed = tq.compress_batch(corpus)
+
+        query = corpus[0]
+        top_idx, top_dists = gpu_l2_search(query, compressed, tq, top_k=5)
+        # Self should be in top results (lossy reconstruction)
+        assert 0 in top_idx, f"Self not in top-5: {top_idx}"
+
+    def test_distances_non_decreasing(self) -> None:
+        from turboquant_pro import TurboQuantPGVector
+        from turboquant_pro.cuda_search import gpu_l2_search
+
+        rng = np.random.default_rng(0)
+        dim = 256
+        corpus = rng.standard_normal((200, dim)).astype(np.float32)
+
+        tq = TurboQuantPGVector(dim=dim, bits=3, seed=42)
+        compressed = tq.compress_batch(corpus)
+
+        query = corpus[0]
+        _, top_dists = gpu_l2_search(query, compressed, tq, top_k=20)
+        for i in range(len(top_dists) - 1):
+            assert top_dists[i] <= top_dists[i + 1] + 1e-5
+
+    def test_squared_matches_sqrt(self) -> None:
+        from turboquant_pro import TurboQuantPGVector
+        from turboquant_pro.cuda_search import gpu_l2_search
+
+        rng = np.random.default_rng(1)
+        dim = 192
+        corpus = rng.standard_normal((100, dim)).astype(np.float32)
+
+        tq = TurboQuantPGVector(dim=dim, bits=3, seed=42)
+        compressed = tq.compress_batch(corpus)
+
+        query = corpus[0]
+        idx_sq, dists_sq = gpu_l2_search(
+            query, compressed, tq, top_k=10, return_squared=True
+        )
+        idx, dists = gpu_l2_search(query, compressed, tq, top_k=10)
+        np.testing.assert_array_equal(idx_sq, idx)
+        np.testing.assert_allclose(np.sqrt(dists_sq), dists, rtol=1e-5)
+
+    def test_rejects_non_3bit(self) -> None:
+        from turboquant_pro import TurboQuantPGVector
+        from turboquant_pro.cuda_search import gpu_l2_search
+
+        tq = TurboQuantPGVector(dim=64, bits=4, seed=42)
+        rng = np.random.default_rng(0)
+        corpus = rng.standard_normal((10, 64)).astype(np.float32)
+        compressed = tq.compress_batch(corpus)
+        with pytest.raises(ValueError, match="3-bit"):
+            gpu_l2_search(corpus[0], compressed, tq, top_k=5)

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -252,6 +252,54 @@ class TestCompressedSearch:
         assert 0 in top_3, "Near-duplicate not in top-3 results"
 
 
+class TestCompressedL2Distance:
+    """Test L2 (Euclidean) distance on compressed embeddings."""
+
+    def test_self_distance_smallest(self) -> None:
+        """A vector's own compressed representation has smallest L2 distance."""
+        tq = TurboQuantPGVector(dim=256, bits=3, seed=42)
+        embs = _random_embeddings(20, 256, seed=0)
+        compressed = tq.compress_batch(embs)
+
+        dists = tq.compressed_l2_distance(embs[0], compressed)
+        assert np.argmin(dists) == 0
+
+    def test_distances_non_negative(self) -> None:
+        tq = TurboQuantPGVector(dim=128, bits=3, seed=42)
+        embs = _random_embeddings(10, 128, seed=1)
+        compressed = tq.compress_batch(embs)
+
+        dists = tq.compressed_l2_distance(embs[0], compressed)
+        assert (dists >= 0).all()
+
+    def test_l2_ranking_matches_exact(self) -> None:
+        """Compressed L2 ranking approximates exact L2 ranking."""
+        tq = TurboQuantPGVector(dim=256, bits=3, seed=42)
+        rng = np.random.default_rng(7)
+
+        query = rng.standard_normal(256).astype(np.float32)
+        near_dup = query + rng.standard_normal(256).astype(np.float32) * 0.05
+        random_embs = rng.standard_normal((18, 256)).astype(np.float32)
+        all_embs = np.vstack([near_dup[np.newaxis], random_embs])
+
+        compressed = tq.compress_batch(all_embs)
+        dists = tq.compressed_l2_distance(query, compressed)
+        # The near-duplicate should be the closest
+        assert np.argmin(dists) == 0
+
+    def test_l2_zero_for_zero_difference(self) -> None:
+        """L2 distance to a vector reconstructed from itself is small."""
+        tq = TurboQuantPGVector(dim=128, bits=4, seed=42)
+        emb = _random_embeddings(1, 128, seed=2)[0]
+        compressed = tq.compress_batch(emb[np.newaxis])
+        # The reconstruction is lossy, but L2 to *the reconstruction*
+        # using the same query should be small relative to typical norms.
+        decompressed = tq.decompress_embedding(compressed[0])
+        dists = tq.compressed_l2_distance(decompressed, compressed)
+        # Distance from a vector to its own reconstruction (already exact).
+        assert dists[0] < 1e-4
+
+
 # ------------------------------------------------------------------ #
 # Storage estimation                                                  #
 # ------------------------------------------------------------------ #

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -111,10 +111,13 @@ try:
     from .cuda_search import (
         gpu_adc_search,  # noqa: F401
         gpu_hamming_search,  # noqa: F401
+        gpu_l2_search,  # noqa: F401
         pack_binary,  # noqa: F401
     )
 
-    __all__.extend(["gpu_adc_search", "gpu_hamming_search", "pack_binary"])
+    __all__.extend(
+        ["gpu_adc_search", "gpu_hamming_search", "gpu_l2_search", "pack_binary"]
+    )
 except Exception:
     pass
 __version__ = "1.0.0"

--- a/turboquant_pro/cuda_search.py
+++ b/turboquant_pro/cuda_search.py
@@ -5,28 +5,36 @@
 """
 GPU-accelerated search on compressed embeddings.
 
-Two search strategies:
+Three search strategies:
 
 1. **ADC (Asymmetric Distance Computation)** for TQ3-packed vectors:
    Precompute a centroid-centroid dot product lookup table (8x8=64 entries
    for 3-bit), then scan packed bytes with table lookups instead of float
    multiply-accumulate.
 
-2. **Binary Hamming search** on sign-quantized PCA vectors:
+2. **L2 (Euclidean) search** for TQ3-packed vectors: Compute squared L2
+   distance in rotated space against centroid-reconstructed vectors.
+   Random rotation is orthogonal, so the distance is preserved.
+
+3. **Binary Hamming search** on sign-quantized PCA vectors:
    Use CUDA ``__popc()`` intrinsic on packed uint64 words for fast
    population count. 384 binary dims = 6 uint64 words per vector.
 
-Both kernels are Volta-compatible (compute 7.0+).
+All kernels are Volta-compatible (compute 7.0+).
 
 Usage::
 
     from turboquant_pro.cuda_search import (
         gpu_adc_search,
         gpu_hamming_search,
+        gpu_l2_search,
     )
 
     # ADC search on TQ3-packed vectors
     scores = gpu_adc_search(query_float, packed_db, norms_db, tq)
+
+    # L2 (Euclidean) search on TQ3-packed vectors
+    top_k_indices, dists = gpu_l2_search(query_float, compressed_db, tq)
 
     # Binary Hamming search
     top_k_indices = gpu_hamming_search(query_binary, db_binary, k=100)
@@ -148,6 +156,94 @@ void adc_3bit_search(
 
     // Scale by norm to get approximate cosine similarity
     scores[vid] = dot * db_norms[vid];
+}
+"""
+
+# ------------------------------------------------------------------ #
+# CUDA kernel: L2 (Euclidean) distance for 3-bit packed vectors       #
+# ------------------------------------------------------------------ #
+#
+# Random rotation is orthogonal, so L2 distance is preserved:
+#   ||q - x||^2 = ||rot(q) - rot(x)||^2
+# In rotated space, rot(x)[d] ≈ centroids[idx[d]] * norm_x, where
+# centroids are the per-dim values used in pgvector.py (already scaled
+# by 1/sqrt(dim)). The host passes in the full-norm rotated query, so
+# we compute squared diff per dim and sum.
+
+L2_3BIT_KERNEL_SRC = r"""
+extern "C" __global__
+void l2_3bit_search(
+    const float* query_rotated_full, // (dim,) full-norm rotated query
+    const unsigned char* db_packed,  // (n_vecs, packed_bytes_per_vec)
+    const float* db_norms,           // (n_vecs,) L2 norms
+    const float* centroids,          // (8,) centroid values (1/sqrt(dim) scaled)
+    float* dists_sq,                 // (n_vecs,) output squared L2 distances
+    int n_vecs,
+    int dim,
+    int packed_bytes_per_vec
+) {
+    int vid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (vid >= n_vecs) return;
+
+    const unsigned char* packed = db_packed + vid * packed_bytes_per_vec;
+    const float norm_x = db_norms[vid];
+    float dist_sq = 0.0f;
+
+    int n_groups = dim / 8;
+    int remainder = dim % 8;
+
+    for (int g = 0; g < n_groups; g++) {
+        int byte_off = g * 3;
+        unsigned int b0 = packed[byte_off + 0];
+        unsigned int b1 = packed[byte_off + 1];
+        unsigned int b2 = packed[byte_off + 2];
+
+        unsigned int idx0 = b0 & 0x7;
+        unsigned int idx1 = (b0 >> 3) & 0x7;
+        unsigned int idx2 = ((b0 >> 6) | (b1 << 2)) & 0x7;
+        unsigned int idx3 = (b1 >> 1) & 0x7;
+        unsigned int idx4 = (b1 >> 4) & 0x7;
+        unsigned int idx5 = ((b1 >> 7) | (b2 << 1)) & 0x7;
+        unsigned int idx6 = (b2 >> 2) & 0x7;
+        unsigned int idx7 = (b2 >> 5) & 0x7;
+
+        int base = g * 8;
+        float d0 = query_rotated_full[base + 0] - centroids[idx0] * norm_x;
+        float d1 = query_rotated_full[base + 1] - centroids[idx1] * norm_x;
+        float d2 = query_rotated_full[base + 2] - centroids[idx2] * norm_x;
+        float d3 = query_rotated_full[base + 3] - centroids[idx3] * norm_x;
+        float d4 = query_rotated_full[base + 4] - centroids[idx4] * norm_x;
+        float d5 = query_rotated_full[base + 5] - centroids[idx5] * norm_x;
+        float d6 = query_rotated_full[base + 6] - centroids[idx6] * norm_x;
+        float d7 = query_rotated_full[base + 7] - centroids[idx7] * norm_x;
+        dist_sq += d0*d0 + d1*d1 + d2*d2 + d3*d3
+                 + d4*d4 + d5*d5 + d6*d6 + d7*d7;
+    }
+
+    if (remainder > 0) {
+        int byte_off = n_groups * 3;
+        unsigned int b0 = packed[byte_off + 0];
+        unsigned int b1 = (byte_off + 1 < packed_bytes_per_vec) ? packed[byte_off + 1] : 0;
+        unsigned int b2 = (byte_off + 2 < packed_bytes_per_vec) ? packed[byte_off + 2] : 0;
+
+        unsigned int indices[8];
+        indices[0] = b0 & 0x7;
+        indices[1] = (b0 >> 3) & 0x7;
+        indices[2] = ((b0 >> 6) | (b1 << 2)) & 0x7;
+        indices[3] = (b1 >> 1) & 0x7;
+        indices[4] = (b1 >> 4) & 0x7;
+        indices[5] = ((b1 >> 7) | (b2 << 1)) & 0x7;
+        indices[6] = (b2 >> 2) & 0x7;
+        indices[7] = (b2 >> 5) & 0x7;
+
+        int base = n_groups * 8;
+        for (int r = 0; r < remainder; r++) {
+            float diff = query_rotated_full[base + r] - centroids[indices[r]] * norm_x;
+            dist_sq += diff * diff;
+        }
+    }
+
+    dists_sq[vid] = dist_sq;
 }
 """
 
@@ -306,6 +402,90 @@ def pack_binary(vectors: np.ndarray) -> np.ndarray:
                 packed[:, w] |= vectors[:, col].astype(np.uint64) << b
 
     return packed
+
+
+def gpu_l2_search(
+    query: np.ndarray,
+    compressed_list: list,
+    tq: TurboQuantPGVector,
+    top_k: int = 10,
+    return_squared: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Search TQ3-packed vectors using GPU L2 (Euclidean) distance.
+
+    Random rotation is orthogonal, so ``||q - x|| = ||rot(q) - rot(x)||``.
+    The kernel computes squared L2 in rotated space against the
+    centroid-reconstructed database vectors.
+
+    Args:
+        query: Float32 query vector (dim,). Must be in the same space as
+            the compressed vectors (raw or PCA-projected).
+        compressed_list: List of CompressedEmbedding from TurboQuantPGVector.
+        tq: The TurboQuantPGVector instance used for compression.
+        top_k: Number of nearest results to return.
+        return_squared: If True, return squared L2 distances (skip the
+            sqrt for ranking-only use).
+
+    Returns:
+        Tuple of (top_k_indices, top_k_distances) as numpy arrays.
+        Lower distance = closer match.
+    """
+    if not _HAS_CUPY:
+        raise RuntimeError("CuPy required for GPU L2 search")
+    if tq.bits != 3:
+        raise ValueError(f"gpu_l2_search currently supports 3-bit only, got {tq.bits}")
+
+    dim = tq.dim
+    n_vecs = len(compressed_list)
+    packed_bytes_per = len(compressed_list[0].packed_bytes)
+
+    # Rotate query at full norm (no unit-normalization, unlike ADC).
+    query = np.asarray(query, dtype=np.float32)
+    query_rotated_full = tq._rotate(query)
+
+    packed_all = np.array(
+        [np.frombuffer(c.packed_bytes, dtype=np.uint8) for c in compressed_list],
+        dtype=np.uint8,
+    )
+    norms_all = np.array([c.norm for c in compressed_list], dtype=np.float32)
+
+    query_gpu = cp.asarray(query_rotated_full)
+    packed_gpu = cp.asarray(packed_all)
+    norms_gpu = cp.asarray(norms_all)
+    centroids_gpu = cp.asarray(tq.centroids)
+    dists_sq_gpu = cp.zeros(n_vecs, dtype=cp.float32)
+
+    kernel = _get_kernel("l2_3bit_search", L2_3BIT_KERNEL_SRC, "l2_3bit_search")
+    block = 256
+    grid = (n_vecs + block - 1) // block
+    kernel(
+        (grid,),
+        (block,),
+        (
+            query_gpu,
+            packed_gpu,
+            norms_gpu,
+            centroids_gpu,
+            dists_sq_gpu,
+            np.int32(n_vecs),
+            np.int32(dim),
+            np.int32(packed_bytes_per),
+        ),
+    )
+    cp.cuda.Stream.null.synchronize()
+
+    dists_sq = cp.asnumpy(dists_sq_gpu)
+
+    if top_k >= n_vecs:
+        top_idx = np.argsort(dists_sq)
+    else:
+        top_idx = np.argpartition(dists_sq, top_k)[:top_k]
+        top_idx = top_idx[np.argsort(dists_sq[top_idx])]
+
+    selected = top_idx[:top_k]
+    if return_squared:
+        return selected, dists_sq[selected]
+    return selected, np.sqrt(np.maximum(dists_sq[selected], 0.0))
 
 
 def gpu_hamming_search(

--- a/turboquant_pro/pgvector.py
+++ b/turboquant_pro/pgvector.py
@@ -535,6 +535,29 @@ class TurboQuantPGVector:
         denom = np.maximum(doc_norms * query_norm, 1e-30)
         return (dots / denom).astype(np.float32)
 
+    def compressed_l2_distance(
+        self,
+        query: np.ndarray,
+        compressed_list: Sequence[CompressedEmbedding],
+    ) -> np.ndarray:
+        """Compute approximate L2 (Euclidean) distance between a query and
+        a set of compressed embeddings.
+
+        Decompresses each embedding and computes ``||query - x||_2``.
+        Smaller is closer (opposite of cosine similarity).
+
+        Args:
+            query: Float32 query embedding of shape (dim,).
+            compressed_list: Sequence of compressed embeddings.
+
+        Returns:
+            1D array of L2 distances, shape (n,), dtype float32.
+        """
+        query = np.asarray(query, dtype=np.float32).ravel()
+        decompressed = self.decompress_batch(compressed_list)
+        diffs = decompressed - query
+        return np.linalg.norm(diffs, axis=1).astype(np.float32)
+
     def compressed_inner_product_search(
         self,
         query_indices: np.ndarray,


### PR DESCRIPTION
Adds L2/Euclidean distance support across all three layers:

- Python: TurboQuantPGVector.compressed_l2_distance() helper, parallel to compressed_cosine_similarity().
- GPU: gpu_l2_search() CUDA kernel for TQ3-packed vectors. Exploits orthogonality of the random rotation: ||q-x|| = ||rot(q)-rot(x)||, then sums squared diffs against centroid-reconstructed DB vectors. Returns sqrt distances by default; pass return_squared=True for ranking-only use.
- pgext: tq_l2_distance() and tq_l2_distance_squared() Rust functions plus the <-> SQL operator on tqvector, mirroring the existing <=> cosine operator.

Tests: 4 CPU tests in test_pgvector.py (self-distance smallest, non-negative, ranking matches exact L2, exact reconstruction is ~0) and 4 GPU tests in test_cuda_search.py (skipped without CuPy).

Caveats:
- gpu_l2_search is currently 3-bit only (mirrors existing 3-bit ADC kernel). Extending to 2/4-bit is a follow-up.
- Rust changes were not compile-tested locally (no PGRX_HOME); they mechanically mirror the existing tq_cosine_dist / <=> path.

Closes #19