### PR TITLE
Fair SOTA comparison (199k + 1M): tq-pro ties OPQ, 4-20x faster build

### DIFF
--- a/benchmarks/RESULTS_gutenberg_1m.md
+++ b/benchmarks/RESULTS_gutenberg_1m.md
@@ -1,0 +1,39 @@
+# VLDB-scale retrieval benchmark — 1M Gutenberg LaBSE embeddings
+
+Real, multilingual: **999,000** passages embedded from 1,146 Project Gutenberg
+books with LaBSE (768-dim), 1,000 held-out queries, exact cosine ground truth,
+Atlas CPU (`OMP_NUM_THREADS=20`). Embeddings built by
+`benchmarks/gutenberg_embed.py`; benchmark by `benchmarks/benchmark_vectordb.py`.
+
+## Fair head-to-head at 32× compression (two-stage = oversample×5 + rerank)
+
+| method | bytes/vec | build s | qps | recall@10 (1-stage) | recall@10 (+rerank) |
+|---|---:|---:|---:|---:|---:|
+| fp32-flat (exact) | 3072 | 3 | 27 | 0.990 | — |
+| faiss-PQ | 96 | 167 | 24 | 0.717 | 0.976 |
+| faiss-IVFPQ | 96 | 366 | **7366** | 0.615 | 0.845 |
+| **faiss-OPQ** | 96 | **529** | 39 | 0.872 | **0.989** |
+| **turboquant-pro** TQ3 | 100 | **131** | 30 | 0.857 | **0.989** |
+
+*(Exact flat tops out at recall@10 0.990 here — numerical ties — so 0.989 is at
+the practical ceiling.)*
+
+## Honest takeaway at 1M scale
+- **Accuracy: tq-pro ties the best baseline (OPQ)** — both 0.989 with fair
+  rerank, at the ~0.99 exact ceiling; both clearly beat PQ (0.976) and IVF-PQ
+  (0.845).
+- **Build cost stays in tq-pro's favor: ~4× faster** (131 s vs OPQ 529 s) on 1M
+  vectors. PCA-Matryoshka needs one eigen-decomposition; OPQ needs iterative
+  rotation+codebook optimization that scales poorly.
+- **Query throughput is a real trade-off:** IVF-PQ is far faster (7366 qps) but
+  much less accurate; tq-pro and OPQ are comparable (~30–40 qps as benchmarked,
+  flat reconstruct search). tq-pro's native ADC/GPU search would raise this —
+  measured separately, not claimed here.
+
+## The defensible VLDB contribution
+A **training-free** pipeline (PCA-Matryoshka makes non-Matryoshka embeddings
+truncatable; +TurboQuant scalar quantization) that reaches **OPQ-class accuracy
+at a fraction of the index-build cost**, on **1M real multilingual vectors**, and
+ships as a deployable SQL-native system (pgvector) — not just a faiss recipe.
+Index construction time is a first-class concern at VLDB scale, and that is where
+this wins.

--- a/benchmarks/RESULTS_labse_199k.md
+++ b/benchmarks/RESULTS_labse_199k.md
@@ -1,30 +1,44 @@
-# Vector-DB retrieval-cost benchmark — real 199k LaBSE embeddings
+# Vector-DB retrieval benchmark — real 199k LaBSE embeddings
 
-Run on Atlas (`/archive/results_aesthetics/bip_sample_200k_labse.npy`, 768-dim,
-199,000 corpus / 1,000 held-out queries, exact cosine ground truth, CPU,
-`OMP_NUM_THREADS=20`). Reproduce with `benchmarks/benchmark_vectordb.py`.
+Atlas, `/archive/results_aesthetics/bip_sample_200k_labse.npy` (768-dim, 199,000
+corpus / 1,000 held-out queries), exact cosine ground truth, CPU,
+`OMP_NUM_THREADS=20`. Reproduce: `benchmarks/benchmark_vectordb.py`.
 
-| method | bytes/vec | comp× | qps | recall@10 | recall@100 |
+## Fair head-to-head at 32× compression (two-stage = oversample×5 + rerank)
+
+Every method gets the same protocol: compressed first stage → rerank the top-50
+candidates by exact fp32 on the retained originals.
+
+| method | bytes/vec | build s | qps | recall@10 (1-stage) | recall@10 (+rerank) |
 |---|---:|---:|---:|---:|---:|
-| fp32-flat (exact) | 3072 | 1.0 | 156 | 0.9997 | 1.000 |
-| faiss-PQ (m=64) | 64 | 48× | 146 | 0.447 | 0.492 |
-| faiss-PQ (m=96) | 96 | 32× | 108 | 0.565 | 0.604 |
-| faiss-PQ (m=128) | 128 | 24× | 668 | 0.658 | 0.693 |
-| faiss-HNSW (fp32, no compression) | 3072 | 1.0 | 2884 | 0.916 | 0.833 |
-| **tq-pro PCA256+TQ2** 1-stage | 68 | 45× | 80 | 0.659 | 0.710 |
-| **tq-pro PCA256+TQ2** +rerank×5 | 68 | 45× | 227 | **0.974** | — |
-| **tq-pro PCA256+TQ3** 1-stage | 100 | 31× | 49 | 0.784 | 0.819 |
-| **tq-pro PCA256+TQ3** +rerank×5 | 100 | 31× | 97 | **0.9993** | — |
-| **tq-pro PCA256+TQ4** 1-stage | 132 | 23× | 120 | 0.882 | 0.907 |
-| **tq-pro PCA256+TQ4** +rerank×5 | 132 | 23× | 227 | **0.9997** | — |
+| fp32-flat (exact) | 3072 | 7 | 212 | 0.9997 | — |
+| faiss-PQ | 96 | 142 | 136 | 0.467 | 0.827 |
+| faiss-IVFPQ | 96 | 355 | 9513 | 0.496 | 0.756 |
+| **faiss-OPQ** | 96 | **632** | 915 | 0.780 | **0.999** |
+| **turboquant-pro** TQ3 | 100 | **31** | 224 | 0.784 | **0.9993** |
 
-## Takeaway
-At matched compression, turboquant-pro **dominates product quantization**: at
-~30–32×, recall@10 **0.9993 vs PQ 0.565**; at ~45×, **0.974 vs 0.447**.
-Single-stage (no rerank) also beats PQ at every budget. Rerank uses the retained
-fp32 originals (standard two-stage ANN); compressed-only storage is the
-`bytes/vec` column. This reproduces the TechRxiv 99.8%@27× claim on real data and
-extends it to 199k scale.
+## Honest takeaway
+- **Accuracy: turboquant-pro ties the strongest baseline (OPQ).** With a fair
+  rerank for all methods, tq-pro recall@10 = 0.9993 vs OPQ 0.999 — a statistical
+  tie — and both clearly beat PQ (0.827) and IVF-PQ (0.756). tq-pro does **not**
+  "dominate" OPQ on recall; the earlier impression was an artifact of giving
+  rerank only to tq-pro.
+- **Build cost is the real win: ~20× faster.** tq-pro builds in **31 s** vs OPQ's
+  **632 s** at equal recall — because it is PCA-based (one eigen-decomposition),
+  not OPQ's expensive iterative rotation+codebook optimization. At VLDB scale,
+  index-construction time matters as much as query time.
+- **Query caveat (honest):** as benchmarked, tq-pro searches a flat index over
+  reconstructed vectors (224 qps) and is slower than OPQ's ADC (915 qps). tq-pro
+  ships a native compressed/ADC + GPU search path (`gpu_adc_search`) that should
+  close this — measuring it is future work, not claimed here.
+- **System advantages (beyond this table):** SQL-native compressed search in
+  pgvector, multi-modal presets, and zero-config `AutoConfig` — none of which the
+  faiss baselines offer.
 
-*Next:* scale to 1M+ (Gutenberg), add OPQ/IVF-PQ/RaBitQ baselines, multi-modal
-(CLIP/MERT), and a standard public dataset — see the sprint.
+## Method contribution (the original novelty)
+PCA-Matryoshka makes **non-Matryoshka embeddings truncatable without retraining**
+(naïve truncation to 256-d: cosine 0.467 → 0.974), which is what lets a
+training-free pipeline reach OPQ-class accuracy at a fraction of the build cost.
+
+*Next:* 1M-scale (Gutenberg), a standard public dataset, multi-modal, and the
+pgvector-native numbers — see the sprint.

--- a/benchmarks/benchmark_vectordb.py
+++ b/benchmarks/benchmark_vectordb.py
@@ -55,6 +55,16 @@ def recall(gt: np.ndarray, ap: np.ndarray, k: int) -> float:
     )
 
 
+def rerank_top10(cand: np.ndarray, Q: np.ndarray, C: np.ndarray) -> np.ndarray:
+    """Two-stage: re-rank candidate ids by exact fp32 cosine on the originals."""
+    rr = np.zeros((len(Q), 10), dtype=np.int64)
+    for i in range(len(Q)):
+        c = cand[i]
+        s = C[c] @ Q[i]
+        rr[i] = c[np.argsort(-s)[:10]]
+    return rr
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--npy", required=True)
@@ -143,6 +153,17 @@ def main() -> int:
                     recall(gt, nn, 100),
                     f"~{bits}-bit budget",
                 )
+                _, cand = index.search(Q, 10 * a.oversample)
+                rr = rerank_top10(cand, Q, C)
+                rec(
+                    f"faiss-{fac}(m={m}) +rerank x{a.oversample}",
+                    m,
+                    bt,
+                    qs,
+                    recall(gt, rr, 10),
+                    float("nan"),
+                    "rerank with fp32 originals",
+                )
             except Exception as e:
                 print(f"  {fac} m={m} failed: {e}", flush=True)
 
@@ -170,6 +191,17 @@ def main() -> int:
                     recall(gt, nn, 10),
                     recall(gt, nn, 100),
                     f"nprobe={index.nprobe}",
+                )
+                _, cand = index.search(Q, 10 * a.oversample)
+                rr = rerank_top10(cand, Q, C)
+                rec(
+                    f"faiss-IVFPQ(m={m}) +rerank x{a.oversample}",
+                    m,
+                    bt,
+                    qs,
+                    recall(gt, rr, 10),
+                    float("nan"),
+                    "rerank with fp32 originals",
                 )
             except Exception as e:
                 print(f"  IVFPQ m={m} failed: {e}", flush=True)


### PR DESCRIPTION
Honest two-stage comparison (rerank for **all** methods). tq-pro **ties OPQ** on recall@10 (199k: 0.9993 vs 0.999; 1M: 0.989 vs 0.989) and builds **4-20x faster**; beats PQ/IVF-PQ. RESULTS for both scales; 1M = real multilingual Gutenberg. Honest 'OPQ-class accuracy at a fraction of build cost, SQL-native' framing.