### PR TITLE
PVLDB paper draft: training-free vector-DB compression

### DIFF
--- a/paper/pca_matryoshka_pvldb.tex
+++ b/paper/pca_matryoshka_pvldb.tex
@@ -1,0 +1,167 @@
+% PCA-Matryoshka for vector-database compression -- PVLDB submission.
+% PVLDB uses the ACM acmart class (sigconf). Compile with pdflatex.
+% Keeps the IEEE/TechRxiv version (pca_matryoshka_ieee_tai.tex) intact.
+\documentclass[sigconf, nonacm]{acmart}
+\settopmatter{printacmref=false}
+\setcopyright{none}
+\renewcommand\footnotetextcopyrightpermission[1]{}
+\pagestyle{plain}
+
+\usepackage{booktabs}
+\usepackage{balance}
+
+\begin{document}
+
+\title{Training-Free Vector-Database Compression: PCA-Matryoshka Truncation and
+Scalar Quantization at OPQ-Class Recall and a Fraction of the Build Cost}
+
+\author{Andrew H. Bond}
+\affiliation{%
+  \institution{San Jose State University}
+  \city{San Jose}\state{CA}\country{USA}}
+\email{andrew.bond@sjsu.edu}
+
+\begin{abstract}
+Billion-scale vector databases pay for every byte: the embedding store dominates
+RAM and storage cost, yet most deployed embedding models cannot be truncated --
+na\"ive dimension reduction destroys retrieval quality, because only models
+trained with a Matryoshka objective place useful information in their leading
+dimensions. We present \textbf{PCA-Matryoshka}, a \emph{training-free} technique
+that applies a PCA rotation to an embedding model's output so that truncation
+becomes effective without retraining (na\"ive truncation of BGE-M3 to 256-d:
+cosine $0.467$; with PCA-Matryoshka: $0.974$). Combined with scalar quantization,
+it compresses embeddings $\sim$30$\times$ for vector search. On real corpora --
+199k LaBSE embeddings and \textbf{1M multilingual Project Gutenberg passages} --
+PCA-Matryoshka matches the strongest learned baseline, OPQ, on recall@10 (a tie
+at the exact-search ceiling, both far above plain PQ and IVF-PQ), while
+\textbf{building the index 4--20$\times$ faster} because it needs a single
+eigen-decomposition rather than OPQ's iterative rotation-plus-codebook
+optimization. We also report a methodological finding with implications for how
+the community evaluates compression: \emph{cosine similarity to the original
+vector is not a reliable proxy for retrieval quality} at high compression. The
+method ships as an open-source system with native PostgreSQL/\texttt{pgvector}
+search over compressed vectors, and a one-click reproduction notebook.
+\end{abstract}
+
+\keywords{vector databases, approximate nearest neighbor search, embedding
+compression, dimension reduction, information retrieval}
+
+\maketitle
+
+\section{Introduction}
+Embedding-based retrieval underpins modern search, recommendation, and
+retrieval-augmented generation. At scale the cost is dominated not by query
+compute but by the \emph{vector store}: hundreds of gigabytes of float32
+embeddings in RAM or on SSD. Compression is therefore a first-class
+data-management problem.
+
+A tempting lever is \emph{truncation}: keep the first $d'$ of $d$ dimensions.
+This works only for models trained with a Matryoshka objective~\cite{mrl}, which
+deliberately front-loads information; the overwhelming majority of deployed
+encoders (BGE-M3, E5, older OpenAI models) were not, and na\"ive truncation
+destroys recall.
+
+\textbf{Contributions.} (1) \textbf{PCA-Matryoshka}, a training-free PCA rotation
+that restores the truncation property for \emph{any} encoder, combined with
+scalar quantization for $\sim$30$\times$ compression. (2) A fair, two-stage
+evaluation on real corpora up to \textbf{1M multilingual vectors} showing
+PCA-Matryoshka \emph{ties the strongest learned baseline (OPQ) on recall while
+building 4--20$\times$ faster}, and beating PQ and IVF-PQ. (3) A methodological
+result: cosine-to-original is not a reliable proxy for retrieval quality under
+aggressive compression. (4) An open-source system with native
+\texttt{pgvector} search over compressed vectors and a reproduction notebook.
+
+\section{Method}
+PCA-Matryoshka fits a PCA on a sample of the corpus and rotates every embedding
+into the principal-component basis, ordering dimensions by explained variance so
+that a prefix of length $d'$ retains the dominant signal. The rotated, truncated
+vector is then scalar-quantized to $b$ bits with a per-corpus codebook and
+bit-packed; the L2 norm is preserved alongside the packed bits. Search is
+two-stage: a compact first stage retrieves candidates, and a rerank stage scores
+a small candidate set with exact distances on the retained originals (the
+standard ANN protocol). The pipeline is \emph{training-free} in the sense that it
+requires only one eigen-decomposition, no gradient training and no iterative
+codebook optimization.
+
+\section{Experiments}
+\textbf{Setup.} Real corpora: (i) 199{,}000 LaBSE embeddings (768-d); (ii)
+\textbf{999{,}000 LaBSE embeddings} of passages drawn from Project Gutenberg
+(multilingual). 1{,}000 held-out queries, exact cosine ground truth. We compare
+against faiss PQ, OPQ, and IVF-PQ at a matched 96-byte ($\sim$32$\times$) budget.
+\emph{Every} method gets the same two-stage protocol (oversample $\times 5$ +
+rerank). Metrics: index build time, queries/s, and recall@10.
+
+\begin{table}[t]
+\caption{Fair two-stage comparison at 32$\times$ compression. PCA-Matryoshka
+(``tq-pro'') ties OPQ on recall while building far faster.}
+\label{tab:main}
+\small
+\begin{tabular}{lrrr}
+\toprule
+& build (s) & qps & recall@10 \\
+\midrule
+\multicolumn{4}{l}{\emph{199k LaBSE}} \\
+\quad PQ            & 142 & 136 & 0.827 \\
+\quad IVF-PQ        & 355 & 9513 & 0.756 \\
+\quad OPQ           & 632 & 915 & 0.999 \\
+\quad \textbf{PCA-Matryoshka} & \textbf{31} & 228 & \textbf{0.9993} \\
+\midrule
+\multicolumn{4}{l}{\emph{1M Gutenberg (multilingual)}} \\
+\quad PQ            & 167 & 24 & 0.976 \\
+\quad IVF-PQ        & 366 & 7366 & 0.845 \\
+\quad OPQ           & 529 & 39 & 0.989 \\
+\quad \textbf{PCA-Matryoshka} & \textbf{131} & 30 & \textbf{0.989} \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\textbf{Result (Table~\ref{tab:main}).} At both scales PCA-Matryoshka \emph{ties}
+OPQ -- the strongest baseline -- on recall@10 (at 1M, 0.989 vs 0.989, against an
+exact-search ceiling of 0.990), and both far exceed PQ and IVF-PQ. The decisive
+difference is \textbf{index build cost}: PCA-Matryoshka builds in 31\,s (199k)
+and 131\,s (1M) versus OPQ's 632\,s and 529\,s -- $4$--$20\times$ faster -- because
+it performs a single eigen-decomposition rather than OPQ's iterative
+rotation+codebook optimization, which scales poorly. We report query throughput
+honestly: IVF-PQ is fastest but least accurate; PCA-Matryoshka and OPQ are
+comparable as benchmarked (a flat reconstruct search), and a native
+asymmetric-distance/GPU search path is left to future work.
+
+\textbf{Truncatability.} On BGE-M3 (not Matryoshka-trained), na\"ive truncation
+to 256-d gives cosine $0.467$ to the full vector; PCA-Matryoshka gives $0.974$ --
+a $109\%$ improvement -- which is what enables the training-free pipeline to reach
+OPQ-class recall.
+
+\textbf{Cosine is not a proxy for recall.} Across configurations, higher
+cosine-to-original does not imply higher recall@10: e.g. PCA-256+TQ3 has
+\emph{lower} cosine ($0.963$) yet \emph{higher} recall@10 ($78.2\%$) than
+PCA-384+TQ3 ($0.979$ cosine, $76.4\%$). Compression methods should be evaluated
+on task-relevant retrieval metrics, not proxy similarity.
+
+\section{System and Reproducibility}
+The method is implemented in an open-source package with connectors for
+\texttt{pgvector}, FAISS, and common vector databases; the \texttt{pgvector}
+path stores \emph{and searches} compressed vectors inside PostgreSQL without
+decompression. A one-click notebook reproduces the compression-vs-recall
+comparison on public data. % anonymized for review
+
+\section{Conclusion}
+A training-free PCA rotation makes any encoder's embeddings truncatable, and
+combined with scalar quantization reaches the accuracy of the strongest learned
+baseline at a fraction of the index-build cost, validated on 1M real
+multilingual vectors. The largest remaining gap -- compressed-domain query
+throughput -- is a systems-engineering target, not a modeling one.
+
+\balance
+\begin{thebibliography}{0}
+\bibitem{mrl} A. Kusupati et al. Matryoshka representation learning. NeurIPS 2022.
+arXiv:2205.13147.
+\bibitem{turboquant} A. Zandieh, M. Daliri, M. Hadian, V. Mirrokni. TurboQuant:
+Online vector quantization with near-optimal distortion rate. arXiv:2504.19874,
+2025.
+\bibitem{opq} T. Ge, K. He, Q. Ke, J. Sun. Optimized product quantization.
+IEEE TPAMI, 2014.
+\bibitem{faiss} J. Johnson, M. Douze, H. J\'egou. Billion-scale similarity search
+with GPUs. IEEE Trans. Big Data, 2021.
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
Data-systems reframe for PVLDB with honest 199k+1M results (ties OPQ, 4-20x faster build). acmart sigconf, compiles clean. IEEE/TechRxiv version untouched. Sprint #17.