### PR TITLE
pgvector-native result (#13)

### DIFF
--- a/benchmarks/FEATURE_COVERAGE.md
+++ b/benchmarks/FEATURE_COVERAGE.md
@@ -11,7 +11,7 @@ industry-standard tool: no feature is claimed without a benchmark behind it.
 | **VLDB scale** | `gutenberg_embed.py` + `benchmark_vectordb.py` | recall@10 **0.989 @ 1M**, ties OPQ | 1M Gutenberg |
 | **Fast index build** (training-free) | `benchmark_vectordb.py` | **4–20× faster build** than OPQ | 199k / 1M |
 | **Rank × bits trade-off** | `benchmark_vectordb.py` (sweep) | spend budget on bit-depth; 85× → 0.89 | 199k LaBSE |
-| **pgvector-native compressed search** | `benchmark_pgvector_real.py` | _(pending #13 — SQL `<=>` over `tqvector`)_ | 50k LaBSE in Postgres |
+| **pgvector-native compressed search** | `benchmark_pgvector_real.py` | compressed search in SQL via `tqvector`+`<=>`; **4.6× smaller** than fp32 @ recall@10 0.90 | 50k LaBSE in Postgres |
 | **KV-cache compression** (RoPE-aware) | `benchmark_edge.py` | **5.3× @ 3-bit** KV memory | analytical + sim |
 | **Edge memory/energy** | `benchmark_edge.py`, `benchmark_e2e.py` | 7B fits 4 GB under TQ (not fp16) | budget + device |
 | **Reproducibility** (public, 1-click) | `notebooks/turboquant_benchmark.ipynb` | Colab reproduces the PQ gap on public data | AG-News |

--- a/benchmarks/RESULTS_pgvector.md
+++ b/benchmarks/RESULTS_pgvector.md
@@ -1,0 +1,27 @@
+# pgvector (fp32) vs tqvector (compressed) — in real PostgreSQL
+
+50,000 real LaBSE embeddings (768-d) loaded into PostgreSQL on Atlas, 500 queries,
+exact cosine ground truth. `pgvector` (`vector` type) vs turboquant-pro's
+`tqvector` extension type, both searched with the `<=>` operator (no ANN index;
+sequential scan). Reproduce: `benchmarks/benchmark_pgvector_real.py`.
+
+| storage | bytes/vec | vs fp32 | insert (s) | q_p50 (ms) | q_p95 (ms) | recall@10 |
+|---|---:|---:|---:|---:|---:|---:|
+| `vector` (fp32) | 4195 | 1× | 33.8 | 252 | 288 | 1.000 |
+| `tqvector` 4-bit | 911 | **4.6×** | 34.2 | 611 | 654 | 0.896 |
+| `tqvector` 3-bit | 631 | 6.6× | 33.3 | 539 | 574 | 0.813 |
+| `tqvector` 2-bit | 456 | 9.2× | 33.9 | 527 | 592 | 0.664 |
+
+## Takeaway
+- **The differentiator works:** compressed vectors are **stored and searched
+  inside standard PostgreSQL** via the `tqvector` type and the `<=>` distance
+  operator — no decompression step, no separate vector-search service. At 4-bit,
+  the column is **4.6× smaller** than fp32 `pgvector` while retaining recall@10
+  0.90 on a single-stage scan.
+- **Honest caveats.** (1) This is the *raw SQL path*: full-dimension scalar
+  quantization, **no PCA-Matryoshka reduction and no rerank**, so recall is lower
+  than the faiss pipeline (which adds both). (2) Query latency is *higher* than
+  fp32 here because there is **no ANN index** and `tq_compress(query)` is computed
+  per query; a `tqvector` ANN index is the obvious next step. The value
+  demonstrated is *deployability* — compressed vector search in the database you
+  already run — not raw query speed.


### PR DESCRIPTION
Compressed vector search in real PostgreSQL via tqvector: 4.6x smaller than fp32 at recall@10 0.90 single-stage. Honest caveats on recall (raw SQL path) and latency (no index).