### PR TITLE
Query-speed verdict: GPU-ADC + ScaNN

### DIFF
--- a/COMPREHENSIVE_ANALYSIS.md
+++ b/COMPREHENSIVE_ANALYSIS.md
@@ -19,7 +19,7 @@ free fast index build, SQL-native compressed search).
 |---|---|
 | Core compression quality | **Strong** — ties OPQ, **beats 2024 SOTA RaBitQ** at both stages (§1) |
 | Index build cost | **Best-in-class** — 4–20× faster than OPQ |
-| Query throughput | **Weakness** — linear scan as benchmarked; GPU-ADC path unmeasured |
+| Query throughput | **Weakness (confirmed)** — flat scan 162 qps; GPU-ADC *measured* at 2.8 qps; needs a batched CUDA kernel |
 | Breadth of integrations | **Exceptional** — pgvector/FAISS/vLLM/NATS/4 vector DBs |
 | Production tooling | **Good** — observability measured; AutoConfig shipped |
 | Test/format rigor | **In progress** — 397 tests; format spec is the gap |
@@ -86,8 +86,10 @@ message bus. Relevant for edge↔cloud. Not independently benchmarked here.
 - **Learned codebooks** (`fit_codebook`, v1.0) — *Documented claim* (cosine
   0.978→0.99 at equal bits); not reproduced here (Atlas system pkg is v0.7.0).
 - **ANS entropy coding** — *Shipped, not benchmarked.*
-- **GPU ADC search** (`gpu_adc_search`, CuPy) — *Shipped;* this is the intended
-  fix for the query-throughput weakness; benchmark pending (#25).
+- **GPU ADC search** (`gpu_adc_search`, CuPy) — *Measured (#25): **2.8 qps***.
+  The per-query Python+CuPy path has crippling launch overhead — *slower* than the
+  CPU flat-reconstruct path (162 qps). It does **not** fix query speed; a batched
+  CUDA ADC kernel would be needed. Honest negative result.
 
 ---
 
@@ -117,10 +119,13 @@ message bus. Relevant for edge↔cloud. Not independently benchmarked here.
   several periphery features shipped but not independently benchmarked; no frozen
   compressed-format spec yet (the #1 standardization gap, see `CODE_QUALITY.md`).
 - **Bottom line:** **A on accuracy** (beats 2024 SOTA RaBitQ, ties OPQ at 1M
-  scale), **A− overall** — held back only by unmeasured compressed-domain query
-  speed. The path to a clear **A+** is narrow and concrete: prove competitive
-  query speed (GPU ADC), benchmark the remaining periphery (multi-modal,
-  AutoConfig), and ship the versioned format spec + conformance suite.
+  scale) and on compression + build cost, **A− overall**. Query speed is now
+  **measured and confirmed as the one real limitation**: tq-pro's flat scan is
+  162–254 qps and its GPU-ADC path only 2.8 qps, while a tuned ANN *system* (ScaNN)
+  does 3441 qps. tq-pro is a best-in-class compression *method*, not a fast ANN
+  *system*. A clean **A+** therefore needs genuine engineering — a batched
+  CUDA ADC kernel or integrating tq-pro codes into a ScaNN-style index — plus the
+  versioned format spec. That is honest future work, not a tweak.
 
 *This document is updated as each pending benchmark lands; see `FEATURE_COVERAGE.md`
 for the per-feature benchmark map and `RESULTS_*.md` for raw numbers.*

--- a/benchmarks/RESULTS_query_speed.md
+++ b/benchmarks/RESULTS_query_speed.md
@@ -1,0 +1,20 @@
+# Query-speed analysis (honest) — the one real tq-pro limitation
+
+Real 50k LaBSE, recall@10. tq-pro **wins recall/compression/build** but is **not a
+fast ANN system**; here is the honest speed picture.
+
+| method | qps | recall@10 | note |
+|---|---:|---:|---|
+| tq-pro flat scan (CPU) | 162–254 | 0.78 (1-stage) / 0.999 (+rerank) | linear scan over codes |
+| tq-pro GPU-ADC (`gpu_adc_search`) | **2.8** | 0.71 | per-query CuPy launch overhead dominates |
+| ScaNN (AH+tree+reorder) | **3441** | 0.72 | tuned fast-ANN *system* |
+| faiss IVF-PQ | 7366 | 0.50–0.85 | sub-linear inverted index |
+
+## Honest conclusion
+turboquant-pro is a **compression method**, not a fast ANN index. It dominates on
+recall and compression and matches OPQ accuracy at far lower build cost, but its
+query throughput (linear scan 162–254 qps) trails tuned ANN systems (ScaNN 3441
+qps), and the shipped GPU-ADC path is *not* a fix (2.8 qps — per-query overhead).
+The route to competitive query speed is a **batched CUDA ADC kernel** or
+**integrating tq-pro codes into a ScaNN-style index** — real engineering, the
+principal future-work item.

--- a/benchmarks/benchmark_scann.py
+++ b/benchmarks/benchmark_scann.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""ScaNN (Google SOTA fast-ANN) baseline on real embeddings.
+
+ScaNN is a complete ANN *system* (anisotropic hashing + tree + reorder), not a
+pure quantizer -- it is the production fast-search bar. Reported alongside
+RaBitQ/OPQ for honest breadth. Run in a scann venv:
+  python benchmark_scann.py --npy /tmp/labse_bench.npy --corpus 100000 --queries 1000
+"""
+
+import argparse
+import time
+
+import numpy as np
+
+
+def exact_topk(Q, C, k):
+    s = Q @ C.T
+    idx = np.argpartition(-s, k, axis=1)[:, :k]
+    for i in range(len(Q)):
+        idx[i] = idx[i][np.argsort(-s[i, idx[i]])]
+    return idx
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--npy", required=True)
+    ap.add_argument("--corpus", type=int, default=100000)
+    ap.add_argument("--queries", type=int, default=1000)
+    a = ap.parse_args()
+    import scann
+
+    X = np.load(a.npy, mmap_mode="r").astype(np.float32)
+    X = X / np.maximum(np.linalg.norm(X, axis=1, keepdims=True), 1e-30)
+    Q = X[: a.queries].copy()
+    C = X[a.queries : a.queries + a.corpus].copy()
+    print(f"corpus={len(C)} dim={X.shape[1]} queries={len(Q)}", flush=True)
+    gt = exact_topk(Q, C, 10)
+
+    t = time.time()
+    searcher = (
+        scann.scann_ops_pybind.builder(C, 10, "dot_product")
+        .tree(num_leaves=2000, num_leaves_to_search=100, training_sample_size=50000)
+        .score_ah(2, anisotropic_quantization_threshold=0.2)
+        .reorder(100)
+        .build()
+    )
+    build_s = time.time() - t
+
+    searcher.search_batched(Q[:10])  # warmup
+    t = time.time()
+    nbrs, _ = searcher.search_batched(Q)
+    qps = len(Q) / (time.time() - t)
+    recall = float(
+        np.mean(
+            [
+                len(set(gt[i].tolist()) & set(nbrs[i].tolist())) / 10
+                for i in range(len(Q))
+            ]
+        )
+    )
+    print(
+        f"\nScaNN: build {build_s:.1f}s | {qps:.0f} qps | recall@10={recall:.4f} "
+        f"(AH+tree+reorder)",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/paper/pca_matryoshka_pvldb.tex
+++ b/paper/pca_matryoshka_pvldb.tex
@@ -134,9 +134,13 @@ PCA-Matryoshka builds $4$--$20\times$ faster (31\,s vs 632\,s at 199k; 131\,s vs
 rotation+codebook optimization. This is exactly the regime that matters when
 indexes are rebuilt often: streaming corpora, periodic re-embedding, and
 multi-tenant systems that build many indexes, where OPQ's minutes-per-index does
-not amortize. On throughput, IVF-PQ is fastest (sub-linear) but least accurate;
-PCA-Matryoshka and OPQ are comparable as benchmarked (linear scan over codes), and
-a GPU asymmetric-distance path is future work.
+not amortize. On throughput, PCA-Matryoshka's linear scan (162--254 qps) is its main
+limitation: tuned ANN \emph{systems} are far faster (ScaNN 3441 qps at recall@10
+$0.72$; IVF-PQ 7366 qps at lower recall), and turboquant-pro's per-query GPU-ADC
+path is \emph{not} throughput-competitive (2.8 qps, dominated by launch overhead).
+PCA-Matryoshka is a \emph{compression} method that wins on recall, compression,
+and build cost; pairing its codes with a fast ANN index (ScaNN-style) is the
+clear route to competitive query speed and is the principal item of future work.
 
 \begin{figure}[t]
 \centering


### PR DESCRIPTION
GPU-ADC 2.8 qps (no fix), ScaNN 3441 qps (the bar). Honest: tq-pro is a compression method, not a fast ANN system. Paper + analysis + RESULTS updated.