### PR TITLE
Path-1 result: NEGATIVE (PCA hurts fast-index recall)

### DIFF
--- a/benchmarks/RESULTS_query_speed.md
+++ b/benchmarks/RESULTS_query_speed.md
@@ -18,3 +18,25 @@ qps), and the shipped GPU-ADC path is *not* a fix (2.8 qps — per-query overhea
 The route to competitive query speed is a **batched CUDA ADC kernel** or
 **integrating tq-pro codes into a ScaNN-style index** — real engineering, the
 principal future-work item.
+
+## Path-1 result (PCA-Matryoshka front-end to fast indexes) — NEGATIVE
+
+Tested the hypothesis "PCA-Matryoshka reduction improves a fast ANN index."
+100k LaBSE, recall@10 (+rerank):
+
+| index | recall@10 (+rerank) | qps | build |
+|---|---:|---:|---:|
+| IVF-PQ raw-768 | **0.782** | 13033 | 194 s |
+| IVF-PQ pca-256 | 0.414 | 44248 | 65 s |
+| HNSW raw-768 | **0.9375** | 3221 | 76 s |
+| HNSW pca-256 | 0.771 | 5331 | 54 s |
+
+**Honest conclusion:** PCA-256 makes the indexes ~3x faster but **drops recall
+substantially** — the dimensionality reduction compounds with the index's own
+approximation. PCA-Matryoshka does **not** improve fast ANN indexes; it does not
+break the speed/recall/compression trade-off. This documents a genuine
+**trilemma**: methods give two of {fast, high-recall, compressed}, not three.
+tq-pro occupies the **high-recall + compressed** corner (flat scan, 162-254 qps);
+plain HNSW gives **fast + high-recall** but uncompressed; PCA+IVF-PQ gives
+**fast + compressed** but low-recall. A method that breaks the trilemma (a fast
+*compressed* ADC) remains the real route to a clean A+.


### PR DESCRIPTION
Honest negative: PCA-256 front-end trades recall for speed in IVF-PQ/HNSW. Documents the speed/recall/compression trilemma. No easy A+.