### PR TITLE
Notebook: ADCIndex fast-search replication section

### DIFF
--- a/notebooks/turboquant_benchmark.ipynb
+++ b/notebooks/turboquant_benchmark.ipynb
@@ -4,13 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# turboquant-pro \u2014 Reproducible Benchmark Suite\n",
+    "# turboquant-pro — Reproducible Benchmark Suite\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ahb-sjsu/turboquant-pro/blob/master/notebooks/turboquant_benchmark.ipynb)\n",
     "\n",
     "Reproduce turboquant-pro's embedding-compression results **end-to-end on public data**, in a few minutes, on CPU (Colab-friendly).\n",
     "\n",
-    "It compares compression ratio, retrieval **recall@10/@100**, and throughput against product quantization (PQ) and an exact baseline. On private 199k LaBSE embeddings turboquant-pro reaches **recall@10 \u2248 0.999 at ~30\u00d7 vs PQ \u2248 0.57** \u2014 this notebook reproduces the same *pattern* on a public dataset so anyone can verify it."
+    "It compares compression ratio, retrieval **recall@10/@100**, and throughput against product quantization (PQ) and an exact baseline. On private 199k LaBSE embeddings turboquant-pro reaches **recall@10 ≈ 0.999 at ~30× vs PQ ≈ 0.57** — this notebook reproduces the same *pattern* on a public dataset so anyone can verify it."
    ]
   },
   {
@@ -200,7 +200,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Compression\u2013recall frontier\n",
+    "## 6. Compression–recall frontier\n",
     "Up and to the right is better: more compression at higher recall."
    ]
   },
@@ -228,9 +228,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Takeaway\n",
+    "## 7. Fast compressed search (`ADCIndex`)\n",
     "\n",
-    "At matched compression, **turboquant-pro dominates PQ on retrieval recall**. The private-data result (199k LaBSE: recall@10 \u2248 0.999 vs PQ \u2248 0.57 at ~30\u00d7) is in [`benchmarks/RESULTS_labse_199k.md`](../benchmarks/RESULTS_labse_199k.md); this notebook reproduces the same pattern on public AG-News embeddings so anyone can verify it on demand."
+    "`ADCIndex` searches the compact codes directly with an asymmetric-distance (ADC) ",
+    "scan instead of decompressing every vector to fp32 per query. It reproduces the ",
+    "pipeline's exact 768-d reconstruct-cosine ranking but much faster via an optional ",
+    "AVX2 kernel, falling back to NumPy when the kernel isn't compiled. The cell below ",
+    "tries to build the kernel (harmless if it fails) and reports recall + qps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import subprocess, sys, time\n",
+    "# (optional) compile the AVX2 kernel for the speedup; NumPy fallback otherwise\n",
+    "try:\n",
+    "    subprocess.run([sys.executable, '-m', 'turboquant_pro._adc'],\n",
+    "                   check=True, capture_output=True, timeout=180)\n",
+    "except Exception as e:\n",
+    "    print('kernel build skipped -> NumPy fallback:', str(e)[:80])\n",
+    "\n",
+    "from turboquant_pro import ADCIndex\n",
+    "pca_f = PCAMatryoshka(input_dim=dim, output_dim=OUT_DIM)\n",
+    "pca_f.fit(C[:min(len(C), 50000)])\n",
+    "index = ADCIndex(pca_f.with_quantizer(bits=3)).add(C)\n",
+    "print('uses_kernel:', index.uses_kernel, '| indexed:', index.size,\n",
+    "      '| bytes/vec:', OUT_DIM * 3 // 8)\n",
+    "\n",
+    "i1, _ = index.search(Q, k=10)\n",
+    "ir = index.search(Q, k=10, rerank=OVERSAMPLE, originals=C)\n",
+    "print(f'ADCIndex recall@10  single={recall(gt, i1, 10):.4f}  +rerank={recall(gt, ir, 10):.4f}')\n",
+    "\n",
+    "def _qps(fn, reps=3):\n",
+    "    best = 1e30\n",
+    "    for _ in range(reps):\n",
+    "        t = time.time(); fn(); best = min(best, time.time() - t)\n",
+    "    return QUERIES / best\n",
+    "\n",
+    "backend = 'AVX2 kernel' if index.uses_kernel else 'NumPy fallback'\n",
+    "print(f'ADCIndex qps (k=10, {backend}): {_qps(lambda: index.search(Q, k=10)):.0f}')\n",
+    "# On a server CPU the kernel reaches ~3700 qps at recall@10 ~0.9995 on 100k LaBSE."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n\nAt matched compression, **turboquant-pro dominates PQ on retrieval recall**. The private-data result (199k LaBSE: recall@10 ≈ 0.999 vs PQ ≈ 0.57 at ~30×) is in [`benchmarks/RESULTS_labse_199k.md`](../benchmarks/RESULTS_labse_199k.md); this notebook reproduces the same pattern on public AG-News embeddings so anyone can verify it on demand.\n\n**Fast search:** `ADCIndex` (section 7) searches the compressed codes directly via a batched ADC scan — on a server CPU it reaches ~3700 qps at recall@10 ~0.9995 (96 B/vector, 7.9x over decompress-and-scan), with a NumPy fallback when the AVX2 kernel isn't compiled."
    ]
   }
  ],


### PR DESCRIPTION
Adds a self-contained ADCIndex section (build kernel + recall/qps) so the fast-search result reproduces on public data.