### PR TITLE
Fix CI: ruff import order + black format

### DIFF
--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -22,6 +22,7 @@ Typical usage::
     compressed = pipeline.compress(embedding)
 """
 
+from .adc_index import ADCIndex
 from .ans_codec import ANSCodec
 from .auto_compress import AutoCompressResult, auto_compress
 from .autoconfig import AutoConfig
@@ -46,7 +47,6 @@ from .modality import (
     get_presets_by_modality,
     list_modality_presets,
 )
-from .adc_index import ADCIndex
 from .monitor import QualityMonitor
 from .nats_codec import TurboQuantNATSCodec
 from .pca import (

--- a/turboquant_pro/_adc/__main__.py
+++ b/turboquant_pro/_adc/__main__.py
@@ -1,4 +1,5 @@
 """Build the ADC kernel: ``python -m turboquant_pro._adc``."""
+
 import sys
 
 from . import build, is_available


### PR DESCRIPTION
ADCIndex import position (I001) + black on _adc/__main__.py. Both CI commands pass locally.