### PR TITLE
Fix citations: correct TurboQuant/PolarQuant/QJL references

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,17 +26,18 @@ keywords:
   - dimensionality-reduction
 references:
   - type: conference-paper
-    title: "Sub-linear Memory Inference via PolarQuant and QJL"
+    title: "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate"
     authors:
       - family-names: Zandieh
         given-names: Amir
-      - family-names: Han
-        given-names: Insu
       - family-names: Daliri
         given-names: Majid
-      - family-names: Karbasi
-        given-names: Amin
+      - family-names: Hadian
+        given-names: Majid
+      - family-names: Mirrokni
+        given-names: Vahab
     year: 2026
+    notes: "arXiv:2504.19874; builds on PolarQuant (arXiv:2502.02617) and QJL (arXiv:2406.03482)"
     collection-title: "International Conference on Learning Representations (ICLR)"
 identifiers:
   - description: "This specific release (v1.0.0)"

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ cfg = AutoConfig.from_dict(model.config.to_dict(), target="compression")
 
 A complete guide to every feature in TurboQuant Pro, the theory behind it, and when to use it.
 
-### Core Compression: PolarQuant + QJL (v0.3.0)
+### Core Compression: TurboQuant (rotate + scalar-quantize) (v0.3.0)
 
 **Theory:** Zandieh et al. (ICLR 2026) showed that a random orthogonal rotation maps vectors onto the unit hypersphere where coordinates become approximately i.i.d. Gaussian. This makes each coordinate independently quantizable with a precomputed Lloyd-Max codebook. The key insight: the rotation decorrelates the dimensions, so scalar quantization (one codebook per coordinate) achieves near-optimal distortion.
 
@@ -530,7 +530,7 @@ Supports Flat, IVF, and HNSW. Save/load indices to disk.
 
 ## How It Works
 
-TurboQuant Pro implements the PolarQuant + QJL algorithm from Zandieh et al. (ICLR 2026) for compressing the key-value cache in transformer inference:
+TurboQuant Pro implements the **TurboQuant** algorithm (Zandieh et al., ICLR 2026) — a random rotation followed by Lloyd-Max scalar quantization, building on the PolarQuant and QJL line of work — for compressing the key-value cache in transformer inference:
 
 ```
                     KV Tensor (B, H, S, D)
@@ -840,11 +840,28 @@ If you use TurboQuant Pro in your research, please cite both this implementation
   year={2026}
 }
 
-@inproceedings{zandieh2026sublinear,
-  title={Sub-linear Memory Inference via PolarQuant and QJL},
-  author={Zandieh, Amir and Han, Insu and Daliri, Majid and Karbasi, Amin},
+@inproceedings{turboquant,
+  title={TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate},
+  author={Zandieh, Amir and Daliri, Majid and Hadian, Majid and Mirrokni, Vahab},
   booktitle={International Conference on Learning Representations (ICLR)},
-  year={2026}
+  year={2026},
+  note={arXiv:2504.19874; combines polar-rotation scalar quantization (``PolarQuant'') with a 1-bit QJL residual}
+}
+
+@inproceedings{qjl,
+  title={QJL: 1-Bit Quantized JL Transform for KV Cache Quantization with Zero Overhead},
+  author={Zandieh, Amir and Daliri, Majid and Han, Insu},
+  booktitle={AAAI Conference on Artificial Intelligence},
+  year={2025},
+  note={arXiv:2406.03482}
+}
+
+@article{polarquant,
+  title={PolarQuant: Quantizing KV Caches with Polar Transformation},
+  author={Han, Insu and Kacham, Praneeth and Karbasi, Amin and Mirrokni, Vahab and Zandieh, Amir},
+  journal={arXiv preprint arXiv:2502.02617},
+  year={2025},
+  note={Random-preconditioning + polar-coordinate scalar quantization; the basis later combined with a 1-bit QJL residual in TurboQuant. A separate, same-named NeurIPS 2025 KV-cache paper (Wu, Lv et al., arXiv:2502.00527) is unrelated.}
 }
 
 @article{devvrit2023matformer,
@@ -863,11 +880,11 @@ If you use TurboQuant Pro in your research, please cite both this implementation
 
 ## Acknowledgments
 
-- **PolarQuant algorithm**: Zandieh, Han, Daliri, and Karbasi — "Sub-linear Memory Inference via PolarQuant and QJL" (ICLR 2026)
+- **Core algorithm**: **TurboQuant** — Zandieh, Daliri, Hadian, Mirrokni, "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate" (ICLR 2026, arXiv:2504.19874), which combines **PolarQuant** (Han, Kacham, Karbasi, Mirrokni, Zandieh — arXiv:2502.02617) with a 1-bit **QJL** residual (Zandieh, Daliri, Han — arXiv:2406.03482). Note: a separate same-named NeurIPS 2025 paper (Wu, Lv et al., arXiv:2502.00527) is unrelated.
 - **MatFormer**: Devvrit et al. — "Nested Transformer for Elastic Inference" (2023). Inspired the model weight compression module.
 - **FLAT-LLM**: "Fine-grained Low-rank Activation Space Transformation for LLM Compression" (2025). Inspired activation-space PCA and head-wise analysis.
 - **Matryoshka Representation Learning**: Kusupati et al. (2022). PCA-Matryoshka extends this concept to non-Matryoshka models via training-free PCA rotation.
-- **Origin**: Adapted from the Theory Radar project's TurboBeam beam-search compression, which first implemented PolarQuant+QJL in Python.
+- **Origin**: Adapted from the Theory Radar project's TurboBeam beam-search compression, which first implemented the TurboQuant rotate-and-scalar-quantize scheme in Python.
 - **Community**: Thanks to DigThatData and others on r/machinelearning for feedback on evaluation methodology, the varimax connection, and the FLAT-LLM pointer.
 - **Author**: Andrew H. Bond, San Jose State University
 

--- a/articles/linkedin.md
+++ b/articles/linkedin.md
@@ -1,6 +1,6 @@
 # TurboQuant Pro v0.8.0: HNSW on Compressed Embeddings, Fused CUDA Kernels, and a 10x Cache
 
-Excited to share v0.8.0 of TurboQuant Pro, our open-source embedding compression library built on the PolarQuant + QJL algorithm (Zandieh et al., ICLR 2026).
+Excited to share v0.8.0 of TurboQuant Pro, our open-source embedding compression library built on the TurboQuant algorithm (Zandieh et al., ICLR 2026).
 
 This release adds three major features:
 

--- a/articles/reddit.md
+++ b/articles/reddit.md
@@ -2,7 +2,7 @@
 
 I've been experimenting with an approach to vector indexing where the HNSW graph nodes store quantized embeddings (~388 bytes each at dim=1024) instead of float32 vectors (~4,096 bytes).
 
-The key insight: if you quantize embeddings using Lloyd-Max scalar quantization after a random orthogonal rotation (the PolarQuant approach from Zandieh et al., ICLR 2026), you can precompute a centroid-centroid inner product table (8x8 = 64 floats for 3-bit). During graph traversal, distance computation becomes 1024 table lookups instead of 1024 float multiplies + accumulate. No decompression needed during search.
+The key insight: if you quantize embeddings using Lloyd-Max scalar quantization after a random orthogonal rotation (the TurboQuant approach from Zandieh et al., ICLR 2026), you can precompute a centroid-centroid inner product table (8x8 = 64 floats for 3-bit). During graph traversal, distance computation becomes 1024 table lookups instead of 1024 float multiplies + accumulate. No decompression needed during search.
 
 Top-k candidates are then decompressed and reranked with exact cosine similarity for the final result.
 

--- a/articles/reddit_paper.md
+++ b/articles/reddit_paper.md
@@ -8,7 +8,7 @@ Result: PCA truncation to 256 dims gives 0.974 cosine similarity. That's a 109% 
 
 ## The compression pipeline
 
-Stack PCA dimension reduction with scalar quantization (3-bit per coordinate, using the PolarQuant rotation trick from Zandieh et al. ICLR 2026):
+Stack PCA dimension reduction with scalar quantization (3-bit per coordinate, using the TurboQuant rotation trick from Zandieh et al. (ICLR 2026)):
 
 1. PCA rotate + truncate to 384 dims (from 1024)
 2. Random orthogonal rotation (makes coordinates ~Gaussian)

--- a/articles/reddit_v2.md
+++ b/articles/reddit_v2.md
@@ -1,6 +1,6 @@
 # [D] Training a 1D codebook on your actual embedding data reduces quantization error 22% vs the Gaussian assumption — quick experiment
 
-Most scalar quantization for embeddings (including TurboQuant/PolarQuant) assumes that after random orthogonal rotation, coordinates are i.i.d. Gaussian. You use precomputed Lloyd-Max centroids for N(0, 1/sqrt(d)) and call it done.
+Most scalar quantization for embeddings (including TurboQuant) assumes that after random orthogonal rotation, coordinates are i.i.d. Gaussian. You use precomputed Lloyd-Max centroids for N(0, 1/sqrt(d)) and call it done.
 
 I was curious how much that assumption actually costs you. So I ran a simple experiment:
 
@@ -25,7 +25,7 @@ I also tested this on KV cache tensors (head_dim=128) and got a similar improvem
 
 **What's interesting theoretically:**
 
-The PolarQuant paper (Zandieh et al. ICLR 2026) proves that random rotation makes coordinates *approximately* Gaussian, but the approximation quality depends on the effective dimensionality of the data. Real embedding models have spectral structure that survives rotation — the coordinates aren't perfectly Gaussian, and the deviation is systematic enough that a data-trained codebook exploits it.
+TurboQuant (Zandieh et al., ICLR 2026) proves that random rotation makes coordinates *approximately* Gaussian, but the approximation quality depends on the effective dimensionality of the data. Real embedding models have spectral structure that survives rotation — the coordinates aren't perfectly Gaussian, and the deviation is systematic enough that a data-trained codebook exploits it.
 
 This connects to older work on optimal quantizer design (Max 1960, Lloyd 1982) — the Lloyd-Max quantizer is only optimal for the distribution it was designed for. If your actual distribution deviates from the assumed one, re-running Lloyd on real data is always at least as good.
 

--- a/articles/turboquant-linkedin.md
+++ b/articles/turboquant-linkedin.md
@@ -12,7 +12,7 @@ A single 1024-dimensional embedding in float32 takes 4,096 bytes. That sounds sm
 
 Most deployed embedding models (BGE-M3, Cohere Embed, older OpenAI models) weren't trained with Matryoshka representation learning, so naive dimension truncation destroys them — cosine similarity drops to 0.467 at half dimensions.
 
-PCA-Matryoshka fixes this with a training-free rotation: fit PCA once on a sample, then rotate all vectors so truncation works. Combined with 3-bit scalar quantization (PolarQuant + Lloyd-Max centroids), the full pipeline delivers:
+PCA-Matryoshka fixes this with a training-free rotation: fit PCA once on a sample, then rotate all vectors so truncation works. Combined with 3-bit scalar quantization (TurboQuant: rotation + Lloyd-Max centroids), the full pipeline delivers:
 
 | Method | Compression | Cosine Sim | Recall@10 |
 |--------|------------|-----------|-----------|

--- a/benchmarks/benchmark_pgvector.py
+++ b/benchmarks/benchmark_pgvector.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/docs/turboquant-expansion-plan.md
+++ b/docs/turboquant-expansion-plan.md
@@ -330,7 +330,7 @@ returns nothing.
 ## References
 
 1. Bond, A.H. "PCA-Matryoshka: Enabling Effective Dimension Reduction for Non-Matryoshka Embedding Models." IEEE TAI, 2026.
-2. Zandieh, Han, Daliri, Karbasi. "Sub-linear Memory Inference via PolarQuant and QJL." ICLR 2026.
+2. Zandieh, Daliri, Hadian, Mirrokni. "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate." ICLR 2026 (arXiv:2504.19874). Builds on PolarQuant (Han, Kacham, Karbasi, Mirrokni, Zandieh; arXiv:2502.02617) and QJL (arXiv:2406.03482).
 3. Karpathy, A. "LLM Knowledge Bases." X post, 2026. (Inspiration for wiki compilation tier.)
 4. Cormack, Clarke, Butt. "Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods." SIGIR 2009.
 5. Johnson, Douze, Jegou. "Billion-scale similarity search with GPUs." IEEE TBBDATA, 2019.

--- a/paper/pca_matryoshka_ieee_tai.bbl
+++ b/paper/pca_matryoshka_ieee_tai.bbl
@@ -63,9 +63,9 @@ T.~Ge, K.~He, Q.~Ke, and J.~Sun, ``{Optimized Product Quantization},'' in
   744--755.
 
 \bibitem{zandieh2026turboquant}
-A.~Zandieh, I.~Han, M.~Daliri, and A.~Karbasi, ``{Sub-linear Memory Inference
-  via PolarQuant and QJL},'' in \emph{International Conference on Learning
-  Representations (ICLR)}, 2026.
+A.~Zandieh, M.~Daliri, M.~Hadian, and V.~Mirrokni, ``{TurboQuant: Online Vector
+  Quantization with Near-optimal Distortion Rate},'' in \emph{International
+  Conference on Learning Representations (ICLR)}, 2026, arXiv:2504.19874.
 
 \bibitem{yagnik2011power}
 J.~Yagnik, D.~Strelow, D.~A. Ross, and R.-S. Lin, ``{The Power of Comparative

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -8,10 +8,26 @@
 }
 
 @inproceedings{zandieh2026turboquant,
-  title={{Sub-linear Memory Inference via PolarQuant and QJL}},
-  author={Zandieh, Amir and Han, Insu and Daliri, Majid and Karbasi, Amin},
+  title={{TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate}},
+  author={Zandieh, Amir and Daliri, Majid and Hadian, Majid and Mirrokni, Vahab},
   booktitle={International Conference on Learning Representations (ICLR)},
-  year={2026}
+  year={2026},
+  note={arXiv:2504.19874}
+}
+
+@article{han2025polarquant,
+  title={{PolarQuant: Quantizing KV Caches with Polar Transformation}},
+  author={Han, Insu and Kacham, Praneeth and Karbasi, Amin and Mirrokni, Vahab and Zandieh, Amir},
+  journal={arXiv preprint arXiv:2502.02617},
+  year={2025}
+}
+
+@inproceedings{zandieh2025qjl,
+  title={{QJL: 1-Bit Quantized JL Transform for KV Cache Quantization with Zero Overhead}},
+  author={Zandieh, Amir and Daliri, Majid and Han, Insu},
+  booktitle={AAAI Conference on Artificial Intelligence},
+  year={2025},
+  note={arXiv:2406.03482}
 }
 
 @article{jegou2011product,

--- a/paper/turboquant_pro.tex
+++ b/paper/turboquant_pro.tex
@@ -16,7 +16,7 @@
 \usepackage{algorithmic}
 \usepackage{xcolor}
 
-\title{TurboQuant Pro: Open-Source PolarQuant+QJL Implementation \\
+\title{TurboQuant Pro: Open-Source TurboQuant Implementation \\
 for LLM KV Cache Compression on Consumer GPUs}
 
 \author{
@@ -32,7 +32,7 @@ for LLM KV Cache Compression on Consumer GPUs}
 
 \begin{abstract}
 We present TurboQuant Pro, the first open-source implementation of the
-PolarQuant + QJL algorithm (Zandieh et al., ICLR 2026) for compressing
+TurboQuant algorithm (Zandieh et al., ICLR 2026) for compressing
 the key-value (KV) cache in large language model inference.  Our
 implementation achieves 5.12$\times$ compression at 0.978 mean cosine
 similarity using 3-bit quantization with bit-packing, and includes a
@@ -57,7 +57,7 @@ typically stored in \texttt{float16}.  For Gemma~4~27B at 8K context, this
 is approximately 1.13\,GB---often exceeding the available VRAM on consumer
 GPUs and limiting the maximum context window.
 
-Zandieh et al.~\cite{zandieh2026sublinear} introduced PolarQuant + QJL, a
+Zandieh et al.~\cite{turboquant} introduced TurboQuant (building on PolarQuant~\cite{polarquant} and QJL~\cite{qjl}), a
 theoretically grounded approach that achieves sub-linear memory scaling by:
 (1)~applying a random orthogonal rotation to map KV vectors onto the unit
 hypersphere where coordinates are approximately i.i.d.\ Gaussian,
@@ -82,7 +82,7 @@ existed prior to ours.  We contribute:
 \section{Method}
 \label{sec:method}
 
-We follow the algorithm of Zandieh et al.~\cite{zandieh2026sublinear}
+We follow the algorithm of Zandieh et al.~\cite{turboquant}
 with the following concrete implementation choices.
 
 \paragraph{Random Rotation.}
@@ -238,7 +238,7 @@ update to store compressed tensors.
 \label{sec:conclusion}
 
 TurboQuant Pro provides the first publicly available implementation of
-Zandieh et al.'s PolarQuant + QJL algorithm for KV cache compression.
+Zandieh et al.'s TurboQuant algorithm for KV cache compression.
 Our implementation achieves 5.1$\times$ memory reduction at 0.978 cosine
 similarity with 3-bit quantization, runs on consumer Volta-class GPUs,
 and includes a streaming tiered cache for autoregressive generation.
@@ -263,11 +263,23 @@ quality--compression trade-off.
 
 \begin{thebibliography}{1}
 
-\bibitem{zandieh2026sublinear}
-Amir Zandieh, Insu Han, Majid Daliri, and Amin Karbasi.
-\newblock Sub-linear memory inference via PolarQuant and QJL.
+\bibitem{turboquant}
+Amir Zandieh, Majid Daliri, Majid Hadian, and Vahab Mirrokni.
+\newblock TurboQuant: Online vector quantization with near-optimal distortion rate.
 \newblock In \emph{International Conference on Learning Representations
-  (ICLR)}, 2026.
+  (ICLR)}, 2026. arXiv:2504.19874.
+
+\bibitem{polarquant}
+Insu Han, Praneeth Kacham, Amin Karbasi, Vahab Mirrokni, and Amir Zandieh.
+\newblock PolarQuant: Quantizing KV caches with polar transformation.
+\newblock arXiv:2502.02617, 2025.
+
+\bibitem{qjl}
+Amir Zandieh, Majid Daliri, and Insu Han.
+\newblock QJL: 1-bit quantized JL transform for KV cache quantization with zero
+  overhead.
+\newblock In \emph{AAAI Conference on Artificial Intelligence}, 2025.
+  arXiv:2406.03482.
 
 \bibitem{lloyd1982least}
 Stuart Lloyd.

--- a/tests/test_ans_codec.py
+++ b/tests/test_ans_codec.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/tests/test_incremental_hnsw.py
+++ b/tests/test_incremental_hnsw.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/ans_codec.py
+++ b/turboquant_pro/ans_codec.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/auto_compress.py
+++ b/turboquant_pro/auto_compress.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/autoconfig.py
+++ b/turboquant_pro/autoconfig.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/cache_adapter.py
+++ b/turboquant_pro/cache_adapter.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/core.py
+++ b/turboquant_pro/core.py
@@ -1,9 +1,10 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 #
-# Algorithm: Zandieh et al. "Sub-linear Memory Inference via PolarQuant
-# and QJL" (ICLR 2026). Implementation adapted from Theory Radar.
+# Algorithm: TurboQuant (Zandieh, Daliri, Hadian, Mirrokni; ICLR 2026; arXiv:2504.19874)
+# -- random rotation + Lloyd-Max scalar quantization; builds on PolarQuant
+# (arXiv:2502.02617) and QJL (arXiv:2406.03482). Adapted from Theory Radar.
 
 """
 TurboQuant KV cache compression for LLM inference.

--- a/turboquant_pro/cuda_kernels.py
+++ b/turboquant_pro/cuda_kernels.py
@@ -1,9 +1,10 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 #
-# Algorithm: Zandieh et al. "Sub-linear Memory Inference via PolarQuant
-# and QJL" (ICLR 2026). Implementation adapted from Theory Radar.
+# Algorithm: TurboQuant (Zandieh, Daliri, Hadian, Mirrokni; ICLR 2026; arXiv:2504.19874)
+# -- random rotation + Lloyd-Max scalar quantization; builds on PolarQuant
+# (arXiv:2502.02617) and QJL (arXiv:2406.03482). Adapted from Theory Radar.
 
 """
 CuPy CUDA RawKernels for GPU-accelerated bit-packing.

--- a/turboquant_pro/export.py
+++ b/turboquant_pro/export.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/hardware.py
+++ b/turboquant_pro/hardware.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/hnsw.py
+++ b/turboquant_pro/hnsw.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/learned_codebook.py
+++ b/turboquant_pro/learned_codebook.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/monitor.py
+++ b/turboquant_pro/monitor.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/nats_codec.py
+++ b/turboquant_pro/nats_codec.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/pgvector.py
+++ b/turboquant_pro/pgvector.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 

--- a/turboquant_pro/rope.py
+++ b/turboquant_pro/rope.py
@@ -1,4 +1,4 @@
-# TurboQuant Pro: Open-source PolarQuant+QJL for LLM KV cache compression
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
 # Copyright (c) 2025 Andrew H. Bond
 # MIT License
 


### PR DESCRIPTION
Replaces the fabricated "Sub-linear Memory Inference via PolarQuant and QJL" citation with the real TurboQuant (2504.19874), PolarQuant (2502.02617), and QJL (2406.03482) papers across the repo + papers. Notes the same-named Wu/Lv NeurIPS 2025 PolarQuant.