### PR TITLE
KV-decode dequant overhead (#1): dequant is 99% of decode step

### DIFF
--- a/benchmarks/RESULTS_decode_overhead.md
+++ b/benchmarks/RESULTS_decode_overhead.md
@@ -1,0 +1,33 @@
+# KV-decode dequantization overhead (#1) — the reviewer is right
+
+For one decode step over an 8192-token cache (head_dim 128, 32 heads, 3-bit), we
+timed the dequant pass (unpack -> centroid lookup -> inverse-rotate -> scale) against
+the attention matmul it feeds. **CPU NumPy path** (Atlas):
+
+| configuration | dequant | attention | dequant share |
+|---|---:|---:|---:|
+| full compressed cache | 1378 ms | 15 ms | **98.9%** |
+| two-tier (512 fp16 hot, 7680 cold) | 1262 ms | 12 ms | 99.1% |
+
+**Dequant dominates the decode step.** The critique is valid. The cost is not the
+unpacking per se but the **inverse-rotation matmul** (a per-head dxd rotation applied
+to every cached token) plus centroid lookup — a separate memory-bound pass before the
+tiny `q.K^T`.
+
+*(The production path is the CuPy GPU kernels; that run errored in this harness
+(`CUDA_ERROR_INVALID_VALUE`) and is not reported here rather than guessed. The CPU
+number already establishes that dequant, not attention, is the decode bottleneck.)*
+
+## The fix is the ADC trick we already built
+Reconstructing K to compute `q.K^T` is wasteful: the inner product can be computed
+**directly on the compressed codes** via asymmetric distance — exactly the kernel that
+made embedding search fast (`turboquant_pro/_adc`). Applied to attention, `q.K^T`
+becomes a per-query LUT over the packed key codes, with **no inverse-rotation and no
+materialized K** — i.e. the *fused dequant-inside-attention* kernel the reviewer asks
+for. So our embedding ADC kernel is the prototype for the KV fused-decode kernel; that
+is the highest-value KV-path work item.
+
+## Mitigations available today
+- **Two-tier cache** keeps the decode-critical hot window in fp16 (zero dequant);
+  only cold pages pay, bounding the cost to the cold fraction.
+- For pure compressed-domain scoring, the ADC path (no reconstruction) is the route.

--- a/benchmarks/benchmark_decode_overhead.py
+++ b/benchmarks/benchmark_decode_overhead.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""#1: How big is the KV dequantization overhead during decode?
+
+The reviewer's concern: unpacking compressed keys back to BF16 each decode step adds
+latency. We quantify it -- for one decode step over an S-token cache, time the
+dequant pass (unpack 3-bit -> centroid lookup -> inverse-rotate -> scale) against the
+attention matmul (q . K^T) it feeds, and report dequant as a fraction of the two.
+Then show how the two-tier cache (fp16 hot window) shrinks it.
+"""
+
+import argparse
+import time
+
+import numpy as np
+
+
+def time_it(fn, reps=20, warmup=3):
+    for _ in range(warmup):
+        fn()
+    best = 1e30
+    for _ in range(reps):
+        t = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - t)
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seq", type=int, default=8192)  # cached tokens
+    ap.add_argument("--head-dim", type=int, default=128)
+    ap.add_argument("--heads", type=int, default=32)
+    ap.add_argument("--bits", type=int, default=3)
+    ap.add_argument("--hot", type=int, default=512)  # fp16 hot window
+    a = ap.parse_args()
+    from turboquant_pro import TurboQuantKV
+
+    rng = np.random.default_rng(0)
+    # cached keys: (heads, seq, head_dim)
+    K = rng.standard_normal((a.heads, a.seq, a.head_dim)).astype(np.float32)
+    q = rng.standard_normal((a.heads, 1, a.head_dim)).astype(np.float32)
+    print(
+        f"seq={a.seq} head_dim={a.head_dim} heads={a.heads} bits={a.bits} hot={a.hot}",
+        flush=True,
+    )
+
+    tq = TurboQuantKV(head_dim=a.head_dim, n_heads=a.heads, bits=a.bits, use_gpu=False)
+    comp = tq.compress(K, packed=True)
+
+    def dequant():
+        return tq.decompress(comp)
+
+    def attn(Kmat):
+        # one decode step: q . K^T  -> softmax-ready scores
+        return np.einsum("hod,hsd->hos", q, Kmat)
+
+    Krec = np.asarray(dequant(), dtype=np.float32).reshape(a.heads, a.seq, a.head_dim)
+    t_dq = time_it(dequant)
+    t_at = time_it(lambda: attn(Krec))
+    frac = t_dq / (t_dq + t_at)
+    print(f"\nFULL compressed cache ({a.seq} tokens):", flush=True)
+    print(f"  dequant   : {t_dq*1e3:8.3f} ms", flush=True)
+    print(f"  attention : {t_at*1e3:8.3f} ms", flush=True)
+    print(f"  dequant is {frac*100:.1f}% of (dequant+attention)", flush=True)
+
+    # two-tier: only cold tokens (seq-hot) are compressed; hot stay fp16 (no dequant)
+    cold = max(a.seq - a.hot, 0)
+    if cold > 0:
+        Kc = K[:, :cold, :].copy()
+        compc = tq.compress(Kc, packed=True)
+        t_dqc = time_it(lambda: tq.decompress(compc))
+        t_atc = time_it(lambda: attn(K))  # attention over the whole cache regardless
+        fracc = t_dqc / (t_dqc + t_atc)
+        print(f"\nTWO-TIER (hot={a.hot} fp16, cold={cold} compressed):", flush=True)
+        print(f"  dequant (cold only): {t_dqc*1e3:8.3f} ms", flush=True)
+        print(f"  attention (full)   : {t_atc*1e3:8.3f} ms", flush=True)
+        print(f"  dequant is {fracc*100:.1f}% of the decode step", flush=True)
+    # GPU path (CuPy kernels) -- the production decode path
+    try:
+        import cupy as cp
+
+        tqg = TurboQuantKV(
+            head_dim=a.head_dim, n_heads=a.heads, bits=a.bits, use_gpu=True
+        )
+        compg = tqg.compress(K, packed=True)
+        Kg, qg = cp.asarray(K), cp.asarray(q)
+
+        def dequant_g():
+            tqg.decompress(compg)
+            cp.cuda.runtime.deviceSynchronize()
+
+        def attn_g():
+            cp.einsum("hod,hsd->hos", qg, Kg)
+            cp.cuda.runtime.deviceSynchronize()
+
+        t_dqg, t_atg = time_it(dequant_g), time_it(attn_g)
+        print("\nGPU (CuPy kernels), full cache:", flush=True)
+        print(f"  dequant   : {t_dqg*1e3:8.3f} ms", flush=True)
+        print(f"  attention : {t_atg*1e3:8.3f} ms", flush=True)
+        print(
+            f"  dequant is {t_dqg/(t_dqg+t_atg)*100:.1f}% of (dequant+attention)",
+            flush=True,
+        )
+    except Exception as e:
+        print(f"\nGPU path unavailable: {str(e)[:70]}", flush=True)
+
+    print(
+        "\n=> The dequant is a separate memory-bound pass; a fused "
+        "dequant-inside-attention kernel removes it (work item). Two-tier bounds "
+        "the cost to the cold fraction.",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Quantifies the reviewer critique: dequant (inverse-rotation matmul) is 99% of the CPU decode step. The embedding ADC kernel generalizes to a fused dequant-in-attention kernel -- the KV work item.