### PR TITLE
Public GloVe-100 benchmark (#10): honest negative + diagnosis

### DIFF
--- a/benchmarks/RESULTS_glove.md
+++ b/benchmarks/RESULTS_glove.md
@@ -1,0 +1,35 @@
+# Standard public benchmark: GloVe-100-angular (#10)
+
+To remove the "all results on private LaBSE" weakness, we ran tq-pro against PQ/OPQ
+on the canonical **GloVe-100-angular** dataset (ann-benchmarks; 1.18M train, scored
+against its provided ground-truth neighbours), 2000 queries, ~16x compression.
+
+| method | bytes/vec | comp x | recall@10 (1-stage) | recall@10 (+rerank) |
+|---|---:|---:|---:|---:|
+| PQ (m=25) | 25 | 16x | 0.520 | 0.862 |
+| OPQ (m=25) | 25 | 16x | 0.523 | 0.866 |
+| tq-pro PCA**64**+TQ3 (explains 73% var) | 24 | 17x | 0.380 | **0.685** |
+| tq-pro PCA**100**+TQ3 (100% var) | 37 | 11x | 0.735 | 0.989 |
+| **tq-pro PCA100+TQ2 (100% var, matched bytes)** | 25 | 16x | 0.574 | **0.906** |
+
+## Honest finding: PCA-Matryoshka truncation is dataset-dependent
+With our *default* PCA-256-style truncation (here PCA-64), tq-pro **loses to PQ/OPQ**
+(0.685 vs 0.862). The diagnostic shows why: **GloVe-100 has no Matryoshka structure
+-- PCA-64 retains only 73% of the variance**, so truncation discards real signal.
+This is the opposite of high-dimensional sentence embeddings (LaBSE 768->256 keeps
+~99%, where tq-pro reaches 0.999 and beats RaBitQ).
+
+## ...but the core quantizer still wins when configured correctly
+With **no truncation** (full 100-d) at the *same byte budget* (PCA100+TQ2 = 25 B),
+tq-pro reaches **0.906 +rerank -- beating PQ (0.862) and OPQ (0.866)**. So the
+TurboQuant scalar quantizer is competitive/better even on GloVe; the failure was
+*truncating data that isn't truncatable*.
+
+## Actionable lesson (-> AutoConfig)
+Truncation depth must track **spectral concentration**: pick the PCA rank from the
+cumulative explained-variance curve (e.g. >=95%), not a fixed dimension. On GloVe
+that means little/no truncation; on LaBSE it means aggressive truncation. This is a
+model/data-aware decision AutoConfig should make automatically -- the honest
+limitation and its fix in one. **Recommendation:** tq-pro's truncation is for
+high-dimensional embeddings with concentrated spectra; for low-dim descriptor sets,
+keep full dimension (still beats PQ) or use PQ.

--- a/benchmarks/benchmark_glove.py
+++ b/benchmarks/benchmark_glove.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""#10: standard public ANN benchmark -- GloVe-100-angular (ann-benchmarks).
+
+Removes the "all results on private LaBSE" weakness: runs tq-pro (ADCIndex) against
+PQ/OPQ at matched compression on the canonical GloVe-100-angular dataset, scored
+against its *provided* ground-truth neighbors (top-100 cosine over the full 1.18M
+corpus). Honest external benchmark.
+"""
+
+import argparse
+import time
+
+import numpy as np
+
+
+def normalize(X):
+    return X / np.maximum(np.linalg.norm(X, axis=1, keepdims=True), 1e-30)
+
+
+def recall(gt, ap, k):
+    return float(
+        np.mean([len(set(gt[i, :k]) & set(ap[i, :k])) / k for i in range(len(gt))])
+    )
+
+
+def rerank(cand, Q, C, k=10):
+    rr = np.full((len(Q), k), -1, dtype=np.int64)
+    for i in range(len(Q)):
+        c = cand[i][cand[i] >= 0]
+        s = C[c] @ Q[i]
+        top = c[np.argsort(-s)[:k]]
+        rr[i, : len(top)] = top
+    return rr
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--hdf5", required=True)
+    ap.add_argument("--queries", type=int, default=2000)
+    ap.add_argument("--pca-dim", type=int, default=64)
+    ap.add_argument("--threads", type=int, default=8)
+    a = ap.parse_args()
+    import faiss
+    import h5py
+
+    faiss.omp_set_num_threads(a.threads)
+    from turboquant_pro import ADCIndex, PCAMatryoshka
+
+    with h5py.File(a.hdf5, "r") as f:
+        C = normalize(np.asarray(f["train"], dtype=np.float32))
+        Qf = normalize(np.asarray(f["test"], dtype=np.float32))
+        nbr = np.asarray(f["neighbors"], dtype=np.int64)
+    nq = min(a.queries, len(Qf))
+    Q, gt = Qf[:nq], nbr[:nq, :10]
+    N, dim = C.shape
+    print(f"GloVe: corpus={N} dim={dim} queries={nq} pca={a.pca_dim}", flush=True)
+
+    def bench(fn, reps=2):
+        best = 1e30
+        for _ in range(reps):
+            t = time.time()
+            fn()
+            best = min(best, time.time() - t)
+        return nq / best
+
+    print("\n| method | bytes/vec | comp x | r@10 (1-stage) | r@10 (+rerank) | qps |")
+    print("|---|---:|---:|---:|---:|---:|")
+
+    # PQ / OPQ at ~matched bytes
+    for fac, m in [("PQ", 25), ("OPQ", 25)]:
+        idx = faiss.index_factory(
+            dim,
+            f"{'OPQ'+str(m)+',' if fac=='OPQ' else ''}PQ{m}",
+            faiss.METRIC_INNER_PRODUCT,
+        )
+        idx.train(C[: min(N, 200000)])
+        idx.add(C)
+        _, i1 = idx.search(Q, 10)
+        _, cand = idx.search(Q, 50)
+        q = bench(lambda idx=idx: idx.search(Q, 10))
+        print(
+            f"| {fac}(m={m}) | {m} | {dim*4/m:.0f} | {recall(gt, i1, 10):.4f} "
+            f"| {recall(gt, rerank(cand, Q, C), 10):.4f} | {q:.0f} |",
+            flush=True,
+        )
+
+    # tq-pro ADCIndex at several (pca-dim, bits) -- isolate truncation vs scalar-quant
+    for pdim, bits in [(a.pca_dim, 3), (dim, 3), (dim, 2)]:
+        pca = PCAMatryoshka(input_dim=dim, output_dim=pdim)
+        pca.fit(C[: min(N, 200000)])
+        ev = float(np.sum(pca._eigenvalues) / np.sum(pca._all_eigenvalues))
+        index = ADCIndex(pca.with_quantizer(bits=bits)).add(C)
+        i1, _ = index.search(Q, k=10)
+        ir = index.search(Q, k=10, rerank=5, originals=C)
+        bpv = pdim * bits // 8
+        q = bench(lambda index=index: index.search(Q, k=10))
+        print(
+            f"| tq-pro PCA{pdim}+TQ{bits} (var={ev:.2f}) | {bpv} | {dim*4/bpv:.0f} "
+            f"| {recall(gt, i1, 10):.4f} | {recall(gt, ir, 10):.4f} | {q:.0f} |",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Default truncation loses on GloVe (no Matryoshka structure, 73% var at 64-d); full-dim tq-pro beats PQ/OPQ at matched bytes. Truncation must track spectral concentration. External-benchmark credibility + honest scoping.