### PR TITLE
Paper + analysis: honest scope from GloVe public benchmark

### DIFF
--- a/COMPREHENSIVE_ANALYSIS.md
+++ b/COMPREHENSIVE_ANALYSIS.md
@@ -41,7 +41,18 @@ Real results (32× compression, two-stage protocol, recall@10):
 (single-stage 0.78 vs 0.63; +rerank 0.999 vs 0.962 — RaBitQ's 1-bit code gives
 weaker candidate recall) and **ties OPQ**, at far lower build cost than OPQ. The
 truncatability result (BGE-M3 256-d: cosine 0.467→0.974) is clean and real. This
-is an **A-grade accuracy result against current SOTA.**
+is an **A-grade accuracy result against current SOTA** for high-dimensional
+embeddings.
+
+**External validation + honest scope (GloVe-100-angular, public).** On the canonical
+ann-benchmarks GloVe-100 set (1.18M, provided ground truth), the *default* PCA-64
+truncation **loses** to PQ/OPQ (recall@10 +rerank 0.685 vs 0.862) — GloVe has no
+Matryoshka structure, so PCA-64 keeps only 73% variance and truncation discards
+signal. With **no truncation** at matched bytes, tq-pro's scalar quantizer still
+**beats** PQ/OPQ (0.906 vs 0.862). **Takeaway:** truncation depth must track spectral
+concentration (AutoConfig's job); PCA-Matryoshka is for high-dim embeddings with
+concentrated spectra, not low-dim descriptor sets. Reporting this loss is deliberate —
+see [`benchmarks/RESULTS_glove.md`](benchmarks/RESULTS_glove.md).
 
 ## 2. KV-cache compression (RoPE-aware) — **Measured (analytical+sim)**
 **Maturity: Production.** `TurboQuantKVCache`, RoPE-aware, hot-window in fp16.

--- a/paper/pca_matryoshka_pvldb.tex
+++ b/paper/pca_matryoshka_pvldb.tex
@@ -171,6 +171,18 @@ to 256-d gives cosine $0.467$ to the full vector; PCA-Matryoshka gives $0.974$ -
 a $109\%$ improvement -- which is what enables the training-free pipeline to reach
 OPQ-class recall.
 
+\textbf{Scope: truncation needs a concentrated spectrum.} The truncation step helps
+only when the PCA spectrum is concentrated, as it is for high-dimensional sentence
+embeddings (LaBSE 768$\to$256-d retains $\sim$99\% variance). On the canonical
+low-dimensional GloVe-100-angular benchmark (ann-benchmarks; 1.18M vectors, provided
+ground truth), PCA-64 retains only $73\%$ of the variance and truncation \emph{hurts}:
+recall@10 (+rerank) falls to $0.685$ vs PQ's $0.862$. With \emph{no} truncation at
+the same byte budget, however, our scalar quantizer still wins (PCA-100+TQ2: $0.906$
+vs PQ $0.862$, OPQ $0.866$). The lesson is that truncation depth should track
+cumulative explained variance (e.g. $\geq 95\%$), an automatic model/data-aware choice;
+PCA-Matryoshka is the right tool for high-dimensional embeddings with spectral
+concentration, not for low-dimensional descriptor sets.
+
 \textbf{Cosine is not a proxy for recall.} Across configurations, higher
 cosine-to-original does not imply higher recall@10: e.g. PCA-256+TQ3 has
 \emph{lower} cosine ($0.963$) yet \emph{higher} recall@10 ($78.2\%$) than


### PR DESCRIPTION
Adds the truncation-needs-spectral-concentration scope to PVLDB + the external-validation note to the analysis. Scopes headline claims to high-dim embeddings.