### PR TITLE
Add suggest_output_dim: variance-aware truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,11 @@ ranking but ~8× faster via an optional AVX2 kernel, with a correct numpy fallba
 ```python
 from turboquant_pro import PCAMatryoshka, ADCIndex
 
-pca = PCAMatryoshka(input_dim=768, output_dim=256).fit(train)
-index = ADCIndex(pca.with_quantizer(bits=3)).add(corpus)   # stores 96 B/vec (32x)
+# pick the truncation dim from the data's spectrum (truncation only helps when
+# variance is concentrated -- LaBSE-768 -> 168 dims @95%, GloVe-100 -> 92 dims @95%)
+d = PCAMatryoshka.suggest_output_dim(corpus, target_variance=0.95)
+pca = PCAMatryoshka(input_dim=768, output_dim=d).fit(train)
+index = ADCIndex(pca.with_quantizer(bits=3)).add(corpus)   # stores ~63 B/vec
 
 idx, scores = index.search(queries, k=10)                  # single-stage, fast
 idx = index.search(queries, k=10, rerank=5, originals=corpus)  # exact rerank → 0.9995

--- a/tests/test_suggest_dim.py
+++ b/tests/test_suggest_dim.py
@@ -1,0 +1,41 @@
+"""Tests for PCAMatryoshka.suggest_output_dim (variance-aware truncation)."""
+
+import numpy as np
+import pytest
+
+from turboquant_pro import PCAMatryoshka
+
+
+def test_concentrated_spectrum_truncates():
+    # rank-10 signal embedded in 100-d -> ~10 dims carry ~all variance
+    rng = np.random.default_rng(0)
+    Z = rng.standard_normal((5000, 10))
+    W = rng.standard_normal((10, 100))
+    X = (Z @ W).astype(np.float32)
+    X += 0.001 * rng.standard_normal((5000, 100)).astype(np.float32)
+    d = PCAMatryoshka.suggest_output_dim(X, target_variance=0.95)
+    assert 8 <= d <= 25  # close to the true rank
+
+
+def test_isotropic_spectrum_keeps_most_dims():
+    # isotropic Gaussian -> no concentration -> need most dims for 95%
+    rng = np.random.default_rng(1)
+    X = rng.standard_normal((5000, 64)).astype(np.float32)
+    d = PCAMatryoshka.suggest_output_dim(X, target_variance=0.95)
+    assert d >= 55  # ~95% of 64 roughly-equal dims
+
+
+def test_monotone_in_target():
+    rng = np.random.default_rng(2)
+    X = rng.standard_normal((3000, 50)).astype(np.float32)
+    assert PCAMatryoshka.suggest_output_dim(
+        X, 0.90
+    ) <= PCAMatryoshka.suggest_output_dim(X, 0.99)
+
+
+def test_validation():
+    X = np.zeros((10, 5), dtype=np.float32)
+    with pytest.raises(ValueError):
+        PCAMatryoshka.suggest_output_dim(X, target_variance=1.5)
+    with pytest.raises(ValueError):
+        PCAMatryoshka.suggest_output_dim(np.zeros(5, dtype=np.float32), 0.95)

--- a/turboquant_pro/pca.py
+++ b/turboquant_pro/pca.py
@@ -238,6 +238,53 @@ class PCAMatryoshka:
         )
         return result
 
+    @staticmethod
+    def suggest_output_dim(
+        embeddings: np.ndarray,
+        target_variance: float = 0.95,
+        sample: int = 20000,
+        seed: int = 0,
+    ) -> int:
+        """Smallest PCA dimension that retains ``target_variance`` of the spectrum.
+
+        Truncation only helps when the spectrum is concentrated. High-dimensional
+        sentence embeddings (e.g. LaBSE 768-d) concentrate ~99% of variance in their
+        first few hundred components, so aggressive truncation is safe; low-dimensional
+        descriptor sets (e.g. GloVe-100) do not, and truncating them discards signal.
+        Use this to pick ``output_dim`` from the data rather than a fixed guess::
+
+            d = PCAMatryoshka.suggest_output_dim(corpus, target_variance=0.95)
+            pca = PCAMatryoshka(input_dim=corpus.shape[1], output_dim=d).fit(corpus)
+
+        Args:
+            embeddings: 2D array ``(n, input_dim)``.
+            target_variance: Cumulative variance to retain, in ``(0, 1]``.
+            sample: Max rows used to estimate the covariance (for speed).
+            seed: RNG seed for subsampling.
+
+        Returns:
+            The smallest dimension whose cumulative explained variance is at least
+            ``target_variance`` (always at least 1, at most ``input_dim``).
+        """
+        X = np.asarray(embeddings, dtype=np.float64)
+        if X.ndim != 2:
+            raise ValueError(f"Expected 2D embeddings, got shape {X.shape}")
+        if not 0.0 < target_variance <= 1.0:
+            raise ValueError("target_variance must be in (0, 1]")
+        if len(X) > sample:
+            rng = np.random.default_rng(seed)
+            X = X[rng.choice(len(X), sample, replace=False)]
+        Xc = X - X.mean(axis=0, keepdims=True)
+        cov = (Xc.T @ Xc) / max(len(Xc) - 1, 1)
+        ev = np.linalg.eigvalsh(cov)[::-1]  # descending
+        ev = np.clip(ev, 0.0, None)
+        total = float(ev.sum())
+        if total <= 0:
+            return 1
+        cum = np.cumsum(ev) / total
+        d = int(np.searchsorted(cum, target_variance) + 1)
+        return max(1, min(d, X.shape[1]))
+
     def partial_fit(self, X: np.ndarray) -> PCAFitResult:
         """Incrementally update PCA with a new batch of embeddings.
 


### PR DESCRIPTION
Picks PCA truncation dim from cumulative explained variance. Validated: GloVe-100->92 dims (avoids the truncation trap), LaBSE-768->168 dims. Turns the honest GloVe limitation into a feature.