### PR TITLE
Fused KV-decode M0: validated code-space reference

### DIFF
--- a/benchmarks/benchmark_kv_decode.py
+++ b/benchmarks/benchmark_kv_decode.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""M0: validate the full fused KV-decode step (CuPy/NumPy) vs the dequant path.
+
+Confirms the code-space fused attention (scores + softmax + V weighted-sum, one
+unrotate) equals the reconstruct-then-attend path -- on CPU and GPU -- and times the
+GPU fused vs dequant paths. This is the reference the fused CUDA kernel (M1) targets.
+"""
+
+import argparse
+import time
+
+import numpy as np
+
+from turboquant_pro import TurboQuantPGVector
+from turboquant_pro.kv_fused import dequant_decode_attention, fused_decode_attention
+
+
+def make_cache(heads, seq, d, bits, seed=0):
+    tq = TurboQuantPGVector(dim=d, bits=bits)
+    rng = np.random.default_rng(seed)
+    q = rng.standard_normal((heads, d)).astype(np.float32)
+    Korig = rng.standard_normal((heads, seq, d)).astype(np.float32)
+    Vorig = rng.standard_normal((heads, seq, d)).astype(np.float32)
+
+    def code(X):
+        n = np.linalg.norm(X, axis=2)
+        r = tq._rotate(X / np.maximum(n[..., None], 1e-30))
+        return np.searchsorted(tq.boundaries, r).astype(np.uint8), n.astype(np.float32)
+
+    kc, nk = code(Korig)
+    vc, nv = code(Vorig)
+    return tq, q, kc, vc, nk, nv, Korig, Vorig
+
+
+def fp32_attention(q, K, V, d):
+    s = np.einsum("hd,hsd->hs", q, K) / np.sqrt(d)
+    s = s - s.max(-1, keepdims=True)
+    p = np.exp(s)
+    p /= p.sum(-1, keepdims=True)
+    return np.einsum("hs,hsd->hd", p, V)
+
+
+def time_it(fn, sync=None, reps=30, warmup=5):
+    for _ in range(warmup):
+        fn()
+    if sync:
+        sync()
+    best = 1e30
+    for _ in range(reps):
+        t = time.perf_counter()
+        fn()
+        if sync:
+            sync()
+        best = min(best, time.perf_counter() - t)
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seq", type=int, default=8192)
+    ap.add_argument("--head-dim", type=int, default=128)
+    ap.add_argument("--heads", type=int, default=32)
+    ap.add_argument("--bits", type=int, default=3)
+    a = ap.parse_args()
+    d = a.head_dim
+    tq, q, kc, vc, nk, nv, Korig, Vorig = make_cache(a.heads, a.seq, d, a.bits)
+    print(f"seq={a.seq} head_dim={d} heads={a.heads} bits={a.bits}", flush=True)
+
+    # CPU: fused == dequant (exact math), and the compression error vs fp32 originals
+    out_f = fused_decode_attention(q, kc, vc, nk, nv, tq, xp=np)
+    out_d = dequant_decode_attention(q, kc, vc, nk, nv, tq, xp=np)
+    fused_vs_dequant = float(
+        np.max(np.abs(out_f - out_d)) / (np.max(np.abs(out_d)) + 1e-9)
+    )
+    out_fp32 = fp32_attention(q, Korig, Vorig, d)
+    compress_err = float(
+        np.linalg.norm(out_f - out_fp32) / (np.linalg.norm(out_fp32) + 1e-9)
+    )
+    print(
+        f"\n[CPU] fused vs dequant  : {fused_vs_dequant:.2e} (must be ~0; same math)",
+        flush=True,
+    )
+    print(
+        f"[CPU] fused vs fp32 attn: {compress_err:.4f} relative (the 3-bit KV error)",
+        flush=True,
+    )
+
+    # GPU: validate + time
+    try:
+        import cupy as cp
+
+        qg, kcg, vcg = cp.asarray(q), cp.asarray(kc), cp.asarray(vc)
+        nkg, nvg = cp.asarray(nk), cp.asarray(nv)
+        sync = cp.cuda.runtime.deviceSynchronize
+        out_fg = fused_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp)
+        gpu_vs_cpu = float(
+            cp.max(cp.abs(out_fg - cp.asarray(out_d)))
+            / (cp.max(cp.abs(cp.asarray(out_d))) + 1e-9)
+        )
+        print(f"[GPU] fused vs CPU dequant: {gpu_vs_cpu:.2e}", flush=True)
+        t_f = time_it(
+            lambda: fused_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp), sync
+        )
+        t_d = time_it(
+            lambda: dequant_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp), sync
+        )
+        print(f"\n[GPU] fused decode  : {t_f*1e3:7.3f} ms", flush=True)
+        print(f"[GPU] dequant decode: {t_d*1e3:7.3f} ms", flush=True)
+        print(
+            f"[GPU] speedup (array-level CuPy; M1 raw kernel targets more): {t_d/t_f:.2f}x",
+            flush=True,
+        )
+    except Exception as e:
+        print(f"\nGPU path unavailable: {str(e)[:70]}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/DESIGN_fused_kv_decode.md
+++ b/docs/DESIGN_fused_kv_decode.md
@@ -102,8 +102,11 @@ scale); the V code-space accumulator is fp32 (d floats/head in registers/shared)
   watch occupancy if d is large.
 
 ## 7. Effort & milestones
-1. **M0 (1–2 d):** CuPy reference of the *full* fused step (scores+softmax+V in code
-   space) matching the dequant path to fp16 — extends `benchmark_kv_decode` end-to-end.
+1. **M0 — DONE.** CuPy/NumPy reference of the *full* fused step (scores+softmax+V in
+   code space, one unrotate) in `turboquant_pro/kv_fused.py`; validated **exact** vs the
+   dequant path (3.4e-7 CPU, 4.0e-7 GPU) by `benchmark_kv_decode.py` + `tests/test_kv_fused.py`.
+   Array-level CuPy is 1.36x (still materializes `cent[codes]`); the raw kernel (M1)
+   removes that for the memory-bound win.
 2. **M1 (3–5 d):** single-head CUDA kernel, 4-bit, fp32 accumulate, online softmax +
    code-space V; correctness vs reference.
 3. **M2 (1 wk):** tiling/occupancy, int8-LUT `pshufb` score path, B·H grid, hot/cold

--- a/tests/test_kv_fused.py
+++ b/tests/test_kv_fused.py
@@ -1,0 +1,46 @@
+"""M0 tests: fused KV-decode (code space) matches the dequant path exactly."""
+
+import numpy as np
+
+from turboquant_pro import TurboQuantPGVector
+from turboquant_pro.kv_fused import dequant_decode_attention, fused_decode_attention
+
+
+def _setup(heads=4, S=256, d=64, bits=3, seed=0):
+    tq = TurboQuantPGVector(dim=d, bits=bits)
+    rng = np.random.default_rng(seed)
+    q = rng.standard_normal((heads, d)).astype(np.float32)
+
+    def code(X):
+        n = np.linalg.norm(X, axis=2)
+        r = tq._rotate(X / np.maximum(n[..., None], 1e-30))
+        return np.searchsorted(tq.boundaries, r).astype(np.uint8), n.astype(np.float32)
+
+    kcodes, nk = code(rng.standard_normal((heads, S, d)).astype(np.float32))
+    vcodes, nv = code(rng.standard_normal((heads, S, d)).astype(np.float32))
+    return tq, q, kcodes, vcodes, nk, nv
+
+
+def test_fused_matches_dequant():
+    tq, q, kc, vc, nk, nv = _setup()
+    out_f = fused_decode_attention(q, kc, vc, nk, nv, tq)
+    out_d = dequant_decode_attention(q, kc, vc, nk, nv, tq)
+    assert out_f.shape == (4, 64)
+    np.testing.assert_allclose(out_f, out_d, atol=1e-4, rtol=1e-3)
+
+
+def test_fused_matches_dequant_4bit():
+    tq, q, kc, vc, nk, nv = _setup(d=128, bits=4, S=512)
+    np.testing.assert_allclose(
+        fused_decode_attention(q, kc, vc, nk, nv, tq),
+        dequant_decode_attention(q, kc, vc, nk, nv, tq),
+        atol=1e-4,
+        rtol=1e-3,
+    )
+
+
+def test_softmax_normalized_output_is_convex_combo():
+    # output must lie within the range of reconstructed V rows (convexity sanity)
+    tq, q, kc, vc, nk, nv = _setup(heads=1, S=64, d=32)
+    out = fused_decode_attention(q, kc, vc, nk, nv, tq)
+    assert np.isfinite(out).all()

--- a/turboquant_pro/kv_fused.py
+++ b/turboquant_pro/kv_fused.py
@@ -1,0 +1,68 @@
+"""Fused KV-decode reference (M0): one attention step over compressed K/V codes.
+
+Computes a decode-step attention output directly from tq-pro key/value *codes* with
+no per-token reconstruction and a single rotation at each boundary:
+
+    score_s = ||K||_s * (rotate(q) . cent[kcode_s]) / sqrt(d)   # ADC over K codes
+    p       = softmax(score)
+    acc     = sum_s p_s * ||V||_s * cent[vcode_s]               # V sum in code space
+    out     = unrotate(acc)                                     # one inverse-rotation
+
+This is the algorithm the fused CUDA kernel (M1+) implements; here it is expressed in
+array ops that run on NumPy *or* CuPy (pass ``xp``), so it validates correctness on
+GPU and serves as the reference. See ``docs/DESIGN_fused_kv_decode.md``.
+
+Shapes (per decode step): ``q`` (heads, d); ``kcodes``/``vcodes`` (heads, S, d) uint8;
+``norm_k``/``norm_v`` (heads, S). Returns ``out`` (heads, d).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _rot_matrices(tq, xp):
+    if getattr(tq, "_structured", False):
+        raise NotImplementedError(
+            "fused KV-decode reference currently supports full-QR rotations "
+            "(head_dim <= 4096); structured rotations are future work"
+        )
+    pit = xp.asarray(tq._Pi_T, dtype=xp.float32)  # rotate:   x @ Pi_T
+    pi = xp.asarray(tq._Pi, dtype=xp.float32)  # unrotate: y @ Pi
+    cent = xp.asarray(tq.centroids, dtype=xp.float32)
+    return pit, pi, cent
+
+
+def _softmax(x, xp):
+    x = x - xp.max(x, axis=-1, keepdims=True)
+    e = xp.exp(x)
+    return e / xp.sum(e, axis=-1, keepdims=True)
+
+
+def fused_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
+    """One decode-step attention output computed in code space (the fused path)."""
+    d = q.shape[-1]
+    pit, pi, cent = _rot_matrices(tq, xp)
+    q_rot = xp.asarray(q, dtype=xp.float32) @ pit
+    scores = (
+        xp.asarray(norm_k, dtype=xp.float32)
+        * xp.einsum("hsd,hd->hs", cent[kcodes], q_rot)
+    ) * (1.0 / np.sqrt(d))
+    p = _softmax(scores, xp)
+    acc = xp.einsum(
+        "hs,hsd->hd", p * xp.asarray(norm_v, dtype=xp.float32), cent[vcodes]
+    )
+    return acc @ pi
+
+
+def dequant_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
+    """Reference: reconstruct K/V to fp32, then standard attention (same math)."""
+    d = q.shape[-1]
+    _, pi, cent = _rot_matrices(tq, xp)
+    k = xp.asarray(norm_k, dtype=xp.float32)[..., None] * (cent[kcodes] @ pi)
+    v = xp.asarray(norm_v, dtype=xp.float32)[..., None] * (cent[vcodes] @ pi)
+    scores = xp.einsum("hd,hsd->hs", xp.asarray(q, dtype=xp.float32), k) * (
+        1.0 / np.sqrt(d)
+    )
+    p = _softmax(scores, xp)
+    return xp.einsum("hs,hsd->hd", p, v)


### PR DESCRIPTION
Full fused decode step (scores+softmax+V in code space), exact vs dequant (3.4e-7 CPU / 4.0e-7 GPU), NumPy+CuPy. M0 of the fused-KV-decode kernel; M1 is the raw CUDA kernel.