### PR TITLE
Fused KV-decode M1: single-head CUDA kernel (correct)

### DIFF
--- a/benchmarks/benchmark_kv_kernel.py
+++ b/benchmarks/benchmark_kv_kernel.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""M1: validate the fused-decode CUDA kernel vs the M0 reference + measure latency.
+
+Confirms the single-head CUDA kernel (online softmax + code-space V) matches the
+NumPy/CuPy reference (kv_fused) to fp tolerance, and times it against the CuPy
+array-level reference and the dequant path.
+"""
+
+import argparse
+import time
+
+import numpy as np
+
+from turboquant_pro import TurboQuantPGVector
+from turboquant_pro.kv_fused import dequant_decode_attention, fused_decode_attention
+from turboquant_pro.kv_kernel import fused_decode_cuda
+
+
+def make_cache(heads, seq, d, bits, seed=0):
+    tq = TurboQuantPGVector(dim=d, bits=bits)
+    rng = np.random.default_rng(seed)
+    q = rng.standard_normal((heads, d)).astype(np.float32)
+
+    def code(X):
+        n = np.linalg.norm(X, axis=2)
+        r = tq._rotate(X / np.maximum(n[..., None], 1e-30))
+        return np.searchsorted(tq.boundaries, r).astype(np.uint8), n.astype(np.float32)
+
+    kc, nk = code(rng.standard_normal((heads, seq, d)).astype(np.float32))
+    vc, nv = code(rng.standard_normal((heads, seq, d)).astype(np.float32))
+    return tq, q, kc, vc, nk, nv
+
+
+def time_it(fn, sync, reps=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    sync()
+    best = 1e30
+    for _ in range(reps):
+        t = time.perf_counter()
+        fn()
+        sync()
+        best = min(best, time.perf_counter() - t)
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seq", type=int, default=8192)
+    ap.add_argument("--head-dim", type=int, default=128)
+    ap.add_argument("--heads", type=int, default=32)
+    ap.add_argument("--bits", type=int, default=4)
+    a = ap.parse_args()
+    import cupy as cp
+
+    tq, q, kc, vc, nk, nv = make_cache(a.heads, a.seq, a.head_dim, a.bits)
+    print(
+        f"seq={a.seq} head_dim={a.head_dim} heads={a.heads} bits={a.bits}", flush=True
+    )
+
+    ref = fused_decode_attention(q, kc, vc, nk, nv, tq, xp=np)  # M0 reference
+    out_k = cp.asnumpy(fused_decode_cuda(q, kc, vc, nk, nv, tq))  # M1 kernel
+    rel = float(np.max(np.abs(out_k - ref)) / (np.max(np.abs(ref)) + 1e-9))
+    print(
+        f"\n[M1] kernel vs M0 reference: {rel:.2e} (online softmax vs direct)",
+        flush=True,
+    )
+
+    qg, kcg, vcg = cp.asarray(q), cp.asarray(kc), cp.asarray(vc)
+    nkg, nvg = cp.asarray(nk), cp.asarray(nv)
+    sync = cp.cuda.runtime.deviceSynchronize
+    t_kernel = time_it(lambda: fused_decode_cuda(qg, kcg, vcg, nkg, nvg, tq), sync)
+    t_ref = time_it(
+        lambda: fused_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp), sync
+    )
+    t_deq = time_it(
+        lambda: dequant_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp), sync
+    )
+    print(f"\n[GPU] M1 fused kernel    : {t_kernel*1e3:7.3f} ms", flush=True)
+    print(f"[GPU] CuPy fused (M0 ref): {t_ref*1e3:7.3f} ms", flush=True)
+    print(f"[GPU] CuPy dequant       : {t_deq*1e3:7.3f} ms", flush=True)
+    print(f"[GPU] kernel speedup vs dequant: {t_deq/t_kernel:.2f}x", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/DESIGN_fused_kv_decode.md
+++ b/docs/DESIGN_fused_kv_decode.md
@@ -107,8 +107,12 @@ scale); the V code-space accumulator is fp32 (d floats/head in registers/shared)
    dequant path (3.4e-7 CPU, 4.0e-7 GPU) by `benchmark_kv_decode.py` + `tests/test_kv_fused.py`.
    Array-level CuPy is 1.36x (still materializes `cent[codes]`); the raw kernel (M1)
    removes that for the memory-bound win.
-2. **M1 (3–5 d):** single-head CUDA kernel, 4-bit, fp32 accumulate, online softmax +
-   code-space V; correctness vs reference.
+2. **M1 — DONE (correctness).** Single-head CUDA kernel (CuPy RawKernel,
+   `turboquant_pro/kv_kernel.py`): one block/head, fp32 online softmax + code-space V,
+   validated **2.5e-6** vs the M0 reference (`benchmark_kv_kernel.py`). It is
+   deliberately *not yet fast* — 0.47× vs dequant — because of low occupancy (32
+   blocks = one per head) and a per-key block reduction (7 syncthreads × S). Those are
+   M2's targets, not bugs.
 3. **M2 (1 wk):** tiling/occupancy, int8-LUT `pshufb` score path, B·H grid, hot/cold
    online-softmax merge; latency vs fp16 flash-decode.
 4. **M3 (3–5 d):** 3-bit support, `TurboQuantKVCache` integration, LongBench/GSM8k

--- a/turboquant_pro/kv_kernel.py
+++ b/turboquant_pro/kv_kernel.py
@@ -1,0 +1,125 @@
+"""M1: single-head fused KV-decode CUDA kernel (CuPy RawKernel).
+
+One thread block per head computes the code-space decode output without
+reconstructing K or V: build a per-query LUT, stream keys with **online (flash)
+softmax** over ADC scores, and accumulate the V weighted-sum in code space; the
+caller applies the single inverse-rotation. Validated against the NumPy/CuPy
+reference in :mod:`turboquant_pro.kv_fused`. See ``docs/DESIGN_fused_kv_decode.md``.
+
+CuPy is imported lazily, so this module loads on CPU-only installs; calling the
+kernel requires a CUDA GPU. Codes are unpacked (one ``uint8`` per dimension) for M1;
+bit-packing is an M2/M3 optimization.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# One block per head; blockDim.x == d (head_dim, a power of two). Online softmax +
+# code-space V accumulation, fp32 accumulators. Uses precise expf for correctness.
+_SRC = r"""
+extern "C" __global__ void fused_decode(
+    const unsigned char* __restrict__ kcodes,   // (H, S, d)
+    const unsigned char* __restrict__ vcodes,   // (H, S, d)
+    const float* __restrict__ norm_k,           // (H, S)
+    const float* __restrict__ norm_v,           // (H, S)
+    const float* __restrict__ q_rot,            // (H, d)  rotated query
+    const float* __restrict__ cent,             // (ncent,)
+    float* __restrict__ out,                     // (H, d) code-space acc, pre-unrotate
+    const int S, const int d, const int ncent, const float scale)
+{
+    const int h = blockIdx.x;
+    const int tid = threadIdx.x;                 // 0..d-1
+    extern __shared__ float sh[];
+    float* lut = sh;                             // d*ncent
+    float* red = lut + d * ncent;                // d (score reduction)
+    __shared__ float m_s, l_s, p_s, corr_s;
+
+    const float qj = q_rot[h * d + tid];
+    for (int s = 0; s < ncent; ++s) lut[tid * ncent + s] = qj * cent[s];
+    if (tid == 0) { m_s = -1e30f; l_s = 0.f; }
+    float acc = 0.f;
+    __syncthreads();
+
+    const unsigned char* kc = kcodes + (size_t)h * S * d;
+    const unsigned char* vc = vcodes + (size_t)h * S * d;
+    const float* nk = norm_k + (size_t)h * S;
+    const float* nv = norm_v + (size_t)h * S;
+
+    for (int s = 0; s < S; ++s) {
+        red[tid] = lut[tid * ncent + kc[(size_t)s * d + tid]];
+        __syncthreads();
+        for (int off = d >> 1; off > 0; off >>= 1) {
+            if (tid < off) red[tid] += red[tid + off];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            float score = nk[s] * red[0] * scale;
+            float mn = fmaxf(m_s, score);
+            corr_s = expf(m_s - mn);
+            p_s = expf(score - mn);
+            l_s = l_s * corr_s + p_s;
+            m_s = mn;
+        }
+        __syncthreads();
+        acc = acc * corr_s + p_s * nv[s] * cent[vc[(size_t)s * d + tid]];
+        __syncthreads();
+    }
+    out[h * d + tid] = acc / l_s;
+}
+"""
+
+_KERNEL = None
+
+
+def _kernel(cp):
+    global _KERNEL
+    if _KERNEL is None:
+        _KERNEL = cp.RawKernel(_SRC, "fused_decode")
+    return _KERNEL
+
+
+def fused_decode_cuda(q, kcodes, vcodes, norm_k, norm_v, tq):
+    """Fused KV-decode on GPU. ``q`` (H, d); codes (H, S, d) uint8; norms (H, S).
+
+    Returns ``out`` (H, d). ``head_dim`` must be a power of two ``<= 1024`` and the
+    rotation must be full-QR (``tq._Pi`` present); structured rotations are future work.
+    """
+    import cupy as cp
+
+    if getattr(tq, "_structured", False):
+        raise NotImplementedError("structured rotation not supported in the M1 kernel")
+    H, d = q.shape
+    S = int(kcodes.shape[1])
+    if d & (d - 1):
+        raise ValueError(f"head_dim must be a power of two for the M1 kernel, got {d}")
+    cent = cp.ascontiguousarray(cp.asarray(tq.centroids, dtype=cp.float32))
+    pit = cp.asarray(tq._Pi_T, dtype=cp.float32)
+    pi = cp.asarray(tq._Pi, dtype=cp.float32)
+    q_rot = cp.ascontiguousarray(cp.asarray(q, dtype=cp.float32) @ pit)
+    kc = cp.ascontiguousarray(cp.asarray(kcodes, dtype=cp.uint8))
+    vc = cp.ascontiguousarray(cp.asarray(vcodes, dtype=cp.uint8))
+    nk = cp.ascontiguousarray(cp.asarray(norm_k, dtype=cp.float32))
+    nv = cp.ascontiguousarray(cp.asarray(norm_v, dtype=cp.float32))
+    out = cp.empty((H, d), dtype=cp.float32)
+    ncent = int(cent.shape[0])
+    shmem = (d * ncent + d) * 4
+    _kernel(cp)(
+        (H,),
+        (d,),
+        (
+            kc,
+            vc,
+            nk,
+            nv,
+            q_rot,
+            cent,
+            out,
+            np.int32(S),
+            np.int32(d),
+            np.int32(ncent),
+            np.float32(1.0 / np.sqrt(d)),
+        ),
+        shared_mem=shmem,
+    )
+    return out @ pi  # single inverse-rotation


### PR DESCRIPTION
CuPy RawKernel, online softmax + code-space V, validated 2.5e-6 vs reference. Correctness milestone (0.47x; perf is M2). CPU-safe lazy import.