### PR TITLE
Fused KV-decode M2: split-K flash-decode (beats dequant up to 13x)

### DIFF
--- a/benchmarks/benchmark_kv_kernel.py
+++ b/benchmarks/benchmark_kv_kernel.py
@@ -59,27 +59,30 @@ def main():
     )
 
     ref = fused_decode_attention(q, kc, vc, nk, nv, tq, xp=np)  # M0 reference
-    out_k = cp.asnumpy(fused_decode_cuda(q, kc, vc, nk, nv, tq))  # M1 kernel
-    rel = float(np.max(np.abs(out_k - ref)) / (np.max(np.abs(ref)) + 1e-9))
-    print(
-        f"\n[M1] kernel vs M0 reference: {rel:.2e} (online softmax vs direct)",
-        flush=True,
-    )
+    for method in ("warp", "block"):
+        out_k = cp.asnumpy(fused_decode_cuda(q, kc, vc, nk, nv, tq, method=method))
+        rel = float(np.max(np.abs(out_k - ref)) / (np.max(np.abs(ref)) + 1e-9))
+        print(f"[{method:5}] kernel vs M0 reference: {rel:.2e}", flush=True)
 
     qg, kcg, vcg = cp.asarray(q), cp.asarray(kc), cp.asarray(vc)
     nkg, nvg = cp.asarray(nk), cp.asarray(nv)
     sync = cp.cuda.runtime.deviceSynchronize
-    t_kernel = time_it(lambda: fused_decode_cuda(qg, kcg, vcg, nkg, nvg, tq), sync)
-    t_ref = time_it(
-        lambda: fused_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp), sync
+    t_w = time_it(
+        lambda: fused_decode_cuda(qg, kcg, vcg, nkg, nvg, tq, method="warp"), sync
+    )
+    t_b = time_it(
+        lambda: fused_decode_cuda(qg, kcg, vcg, nkg, nvg, tq, method="block"), sync
     )
     t_deq = time_it(
         lambda: dequant_decode_attention(qg, kcg, vcg, nkg, nvg, tq, xp=cp), sync
     )
-    print(f"\n[GPU] M1 fused kernel    : {t_kernel*1e3:7.3f} ms", flush=True)
-    print(f"[GPU] CuPy fused (M0 ref): {t_ref*1e3:7.3f} ms", flush=True)
-    print(f"[GPU] CuPy dequant       : {t_deq*1e3:7.3f} ms", flush=True)
-    print(f"[GPU] kernel speedup vs dequant: {t_deq/t_kernel:.2f}x", flush=True)
+    print(f"\n[GPU] M2 warp kernel : {t_w*1e3:7.3f} ms", flush=True)
+    print(f"[GPU] M1 block kernel: {t_b*1e3:7.3f} ms", flush=True)
+    print(f"[GPU] CuPy dequant   : {t_deq*1e3:7.3f} ms", flush=True)
+    print(
+        f"[GPU] warp vs dequant: {t_deq/t_w:.2f}x   warp vs block: {t_b/t_w:.1f}x",
+        flush=True,
+    )
 
 
 if __name__ == "__main__":

--- a/docs/DESIGN_fused_kv_decode.md
+++ b/docs/DESIGN_fused_kv_decode.md
@@ -113,8 +113,13 @@ scale); the V code-space accumulator is fp32 (d floats/head in registers/shared)
    deliberately *not yet fast* — 0.47× vs dequant — because of low occupancy (32
    blocks = one per head) and a per-key block reduction (7 syncthreads × S). Those are
    M2's targets, not bugs.
-3. **M2 (1 wk):** tiling/occupancy, int8-LUT `pshufb` score path, B·H grid, hot/cold
-   online-softmax merge; latency vs fp16 flash-decode.
+3. **M2 — DONE (performance).** Split-K flash-decode (`fused_decode_split` in
+   `turboquant_pro/kv_kernel.py`): one warp per (head, key-split), `__shfl_xor` score
+   reduction (no `__syncthreads`/shared LUT), host-side flash-combine across splits.
+   Correct (5–7e-7 vs reference) and **beats the dequant path 1.8× @2k, 5.1× @8k,
+   13.3× @32k** context — the kernel stays ~1–2 ms while dequant scales with context,
+   so the win widens where long-context decode hurts. Remaining M2 polish (int8-LUT
+   `pshufb` score path, hot/cold online-softmax merge) folds into M3.
 4. **M3 (3–5 d):** 3-bit support, `TurboQuantKVCache` integration, LongBench/GSM8k
    neutrality, docs.
 

--- a/turboquant_pro/kv_kernel.py
+++ b/turboquant_pro/kv_kernel.py
@@ -69,30 +69,93 @@ extern "C" __global__ void fused_decode(
 }
 """
 
-_KERNEL = None
+# M2 fast path: split-K flash-decode. One warp per (head, key-split); each lane owns
+# d/32 dims (stride 32) and holds its q_rot in registers; the per-key score is an
+# all-reduce via __shfl_xor (warp-synchronous -- no __syncthreads, no shared LUT).
+# Each warp emits an UNnormalized partial (running max m, denom l, code-space acc) for
+# its key range; a cheap host-side flash-combine merges splits per head. Splitting the
+# keys gives H*nsplit blocks (occupancy) and parallelizes the otherwise-serial S loop.
+# Requires d % 32 == 0 and d/32 <= 16.
+_SRC_SPLIT = r"""
+extern "C" __global__ void fused_decode_split(
+    const unsigned char* __restrict__ kcodes,
+    const unsigned char* __restrict__ vcodes,
+    const float* __restrict__ norm_k,
+    const float* __restrict__ norm_v,
+    const float* __restrict__ q_rot,
+    const float* __restrict__ cent,
+    float* __restrict__ m_out,      // (H, nsplit)
+    float* __restrict__ l_out,      // (H, nsplit)
+    float* __restrict__ acc_out,    // (H, nsplit, d)  unnormalized
+    const int H, const int S, const int d, const int ncent,
+    const float scale, const int nsplit)
+{
+    const int warps = blockDim.x >> 5;
+    const int gw = blockIdx.x * warps + (threadIdx.x >> 5);  // global warp id
+    const int h = gw / nsplit, split = gw % nsplit;
+    const int lane = threadIdx.x & 31;
+    if (h >= H) return;
+    const int chunk = (S + nsplit - 1) / nsplit;
+    const int s0 = split * chunk;
+    const int s1 = min(s0 + chunk, S);
+    const int ndl = d >> 5;
+    float qr[16], acc[16];
+    #pragma unroll
+    for (int i = 0; i < ndl; ++i) {
+        qr[i] = q_rot[h * d + lane + (i << 5)]; acc[i] = 0.f;
+    }
+    const unsigned char* kc = kcodes + (size_t)h * S * d;
+    const unsigned char* vc = vcodes + (size_t)h * S * d;
+    const float* nk = norm_k + (size_t)h * S;
+    const float* nv = norm_v + (size_t)h * S;
+    float m = -1e30f, l = 0.f;
+    for (int s = s0; s < s1; ++s) {
+        const size_t base = (size_t)s * d + lane;
+        float partial = 0.f;
+        #pragma unroll
+        for (int i = 0; i < ndl; ++i) partial += qr[i] * cent[kc[base + (i << 5)]];
+        for (int o = 16; o > 0; o >>= 1)
+            partial += __shfl_xor_sync(0xffffffffu, partial, o);
+        const float score = nk[s] * partial * scale;
+        const float mn = fmaxf(m, score);
+        const float corr = expf(m - mn), p = expf(score - mn);
+        l = l * corr + p; m = mn;
+        const float pv = p * nv[s];
+        #pragma unroll
+        for (int i = 0; i < ndl; ++i)
+            acc[i] = acc[i] * corr + pv * cent[vc[base + (i << 5)]];
+    }
+    const int po = h * nsplit + split;
+    if (lane == 0) { m_out[po] = m; l_out[po] = l; }
+    #pragma unroll
+    for (int i = 0; i < ndl; ++i) acc_out[(size_t)po * d + lane + (i << 5)] = acc[i];
+}
+"""
+
+_KERNEL = {}
 
 
-def _kernel(cp):
-    global _KERNEL
-    if _KERNEL is None:
-        _KERNEL = cp.RawKernel(_SRC, "fused_decode")
-    return _KERNEL
+def _kernel(cp, name, src):
+    k = _KERNEL.get(name)
+    if k is None:
+        k = _KERNEL[name] = cp.RawKernel(src, name)
+    return k
 
 
-def fused_decode_cuda(q, kcodes, vcodes, norm_k, norm_v, tq):
+def fused_decode_cuda(q, kcodes, vcodes, norm_k, norm_v, tq, method="warp"):
     """Fused KV-decode on GPU. ``q`` (H, d); codes (H, S, d) uint8; norms (H, S).
 
-    Returns ``out`` (H, d). ``head_dim`` must be a power of two ``<= 1024`` and the
-    rotation must be full-QR (``tq._Pi`` present); structured rotations are future work.
+    Returns ``out`` (H, d). ``method="warp"`` (default) is the M2 fast path (one warp
+    per head, ``__shfl`` score reduction, ``d % 32 == 0``); ``method="block"`` is the
+    M1 reference (one block/head, block reduction, ``d`` a power of two). The rotation
+    must be full-QR (``tq._Pi`` present); structured rotations are future work.
     """
     import cupy as cp
 
     if getattr(tq, "_structured", False):
-        raise NotImplementedError("structured rotation not supported in the M1 kernel")
+        raise NotImplementedError("structured rotation not supported by the kernel")
     H, d = q.shape
     S = int(kcodes.shape[1])
-    if d & (d - 1):
-        raise ValueError(f"head_dim must be a power of two for the M1 kernel, got {d}")
     cent = cp.ascontiguousarray(cp.asarray(tq.centroids, dtype=cp.float32))
     pit = cp.asarray(tq._Pi_T, dtype=cp.float32)
     pi = cp.asarray(tq._Pi, dtype=cp.float32)
@@ -101,25 +164,68 @@ def fused_decode_cuda(q, kcodes, vcodes, norm_k, norm_v, tq):
     vc = cp.ascontiguousarray(cp.asarray(vcodes, dtype=cp.uint8))
     nk = cp.ascontiguousarray(cp.asarray(norm_k, dtype=cp.float32))
     nv = cp.ascontiguousarray(cp.asarray(norm_v, dtype=cp.float32))
-    out = cp.empty((H, d), dtype=cp.float32)
     ncent = int(cent.shape[0])
-    shmem = (d * ncent + d) * 4
-    _kernel(cp)(
-        (H,),
-        (d,),
-        (
-            kc,
-            vc,
-            nk,
-            nv,
-            q_rot,
-            cent,
-            out,
-            np.int32(S),
-            np.int32(d),
-            np.int32(ncent),
-            np.float32(1.0 / np.sqrt(d)),
-        ),
-        shared_mem=shmem,
-    )
+    scale = np.float32(1.0 / np.sqrt(d))
+
+    if method == "warp":
+        if d % 32 or d // 32 > 16:
+            raise ValueError(f"warp kernel needs d % 32 == 0 and d/32 <= 16, got {d}")
+        nsplit = max(1, min(32, (S + 511) // 512))  # split-K for occupancy
+        m_p = cp.empty((H, nsplit), dtype=cp.float32)
+        l_p = cp.empty((H, nsplit), dtype=cp.float32)
+        acc_p = cp.empty((H, nsplit, d), dtype=cp.float32)
+        warps = 4
+        total = H * nsplit
+        grid = ((total + warps - 1) // warps,)
+        _kernel(cp, "fused_decode_split", _SRC_SPLIT)(
+            grid,
+            (32 * warps,),
+            (
+                kc,
+                vc,
+                nk,
+                nv,
+                q_rot,
+                cent,
+                m_p,
+                l_p,
+                acc_p,
+                np.int32(H),
+                np.int32(S),
+                np.int32(d),
+                np.int32(ncent),
+                scale,
+                np.int32(nsplit),
+            ),
+        )
+        # flash-combine the unnormalized partials across splits (cheap, on GPU)
+        m = m_p.max(axis=1, keepdims=True)
+        w = cp.exp(m_p - m)
+        denom = (l_p * w).sum(axis=1, keepdims=True)
+        acc = (acc_p * w[:, :, None]).sum(axis=1)
+        return (acc / cp.maximum(denom, 1e-30)) @ pi
+    elif method == "block":
+        if d & (d - 1):
+            raise ValueError(f"block kernel needs head_dim a power of two, got {d}")
+        out = cp.empty((H, d), dtype=cp.float32)
+        _kernel(cp, "fused_decode", _SRC)(
+            (H,),
+            (d,),
+            (
+                kc,
+                vc,
+                nk,
+                nv,
+                q_rot,
+                cent,
+                out,
+                np.int32(S),
+                np.int32(d),
+                np.int32(ncent),
+                scale,
+            ),
+            shared_mem=(d * ncent + d) * 4,
+        )
+    else:
+        raise ValueError(f"unknown method {method!r}")
     return out @ pi  # single inverse-rotation


### PR DESCRIPTION
Split-K + __shfl score reduction. Correct (5-7e-7) and 1.8x/5.1x/13.3x faster than dequant at 2k/8k/32k context; win widens with context. M1 block kernel kept as reference.