### PR TITLE
AutoConfig: default keys to 4-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ from turboquant_pro import TurboQuantKV
 
 # Auto-configure from model name — picks optimal K/V bits, RoPE-awareness
 tq = TurboQuantKV.from_model("llama-3-8b")           # balanced (K4/V3)
-tq = TurboQuantKV.from_model("gemma-2-27b", target="compression")  # K3/V2
+tq = TurboQuantKV.from_model("gemma-2-27b", target="compression")  # K4/V2
 
 compressed_k = tq.compress(kv_key_tensor, packed=True, kind="key")    # 4-bit keys
 compressed_v = tq.compress(kv_val_tensor, packed=True, kind="value")  # 3-bit values
@@ -246,8 +246,14 @@ cfg = AutoConfig.from_dict(model.config.to_dict(), target="compression")
 |--------|--------|-----------|-------|----------|
 | `quality` | K4/V4 + RoPE | 0.995 | 3.8x | Maximum accuracy |
 | `balanced` | K4/V3 + RoPE | 0.995 / 0.978 | 4.3x | **Recommended default** |
-| `compression` | K3/V2 + RoPE | 0.978 / 0.941 | 5.8x | Memory-constrained |
-| `extreme` | K2/V2 | 0.941 | 7.1x | Maximum compression |
+| `compression` | K4/V2 + RoPE | 0.995 / 0.926 | 5.3x | Memory-constrained |
+| `extreme` | K2/V2 | 0.941 | 7.1x | Maximum compression (opt-in) |
+
+**Keys default to 4-bit.** Attention scores `softmax(QKᵀ/√d)` amplify key-quantization
+error through the softmax — on real Qwen2.5-7B activations, 4-bit keys roughly halve
+the per-layer attention error vs 3-bit (~5% vs ~12% with an fp16 sink+hot window; see
+[`benchmarks/RESULTS_longbench.md`](benchmarks/RESULTS_longbench.md)). Values carry the
+compression. Only `extreme` drops keys below 4-bit.
 
 **Supported models:** LLaMA 3 (8B, 70B), Gemma 2 (9B, 27B), Gemma 4 27B-A4B (262K context MoE), Qwen 2.5 (7B, 72B), Mistral 7B. Any HuggingFace model works via `transformers.AutoConfig`.
 
@@ -463,7 +469,7 @@ Each release improved compression quality or added new capabilities. Measured on
 
 **Auto-config memory savings (8K context, fp16 baseline):**
 
-| Model | fp16 | Balanced (K4/V3) | Compression (K3/V2) | Extreme (K2/V2) |
+| Model | fp16 | Balanced (K4/V3) | Compression (K4/V2) | Extreme (K2/V2) |
 |-------|------|-----------------|--------------------|--------------  |
 | LLaMA 3 8B | 1.0 GB | 0.23 GB (4.3x) | 0.17 GB (5.8x) | 0.14 GB (7.1x) |
 | Gemma 2 27B | 6.0 GB | 1.36 GB (4.4x) | 0.98 GB (6.1x) | 0.80 GB (7.5x) |

--- a/tests/test_autoconfig_keybits.py
+++ b/tests/test_autoconfig_keybits.py
@@ -1,0 +1,15 @@
+"""Keys default to 4-bit in AutoConfig (attention scores amplify key-quant error)."""
+
+from turboquant_pro.autoconfig import _TARGETS
+
+
+def test_keys_4bit_except_extreme():
+    for name, p in _TARGETS.items():
+        if name == "extreme":
+            continue
+        assert p["key_bits"] == 4, f"{name} should default keys to 4-bit"
+
+
+def test_compression_is_k4_v2():
+    assert _TARGETS["compression"]["key_bits"] == 4
+    assert _TARGETS["compression"]["value_bits"] == 2

--- a/turboquant_pro/autoconfig.py
+++ b/turboquant_pro/autoconfig.py
@@ -134,6 +134,13 @@ _MODEL_ALIASES: dict[str, str] = {
 # ------------------------------------------------------------------ #
 # Target presets                                                       #
 # ------------------------------------------------------------------ #
+#
+# Keys default to 4-bit. Attention scores are softmax(QK^T/sqrt(d)), so key
+# quantization error is amplified through the softmax: on real Qwen2.5-7B
+# activations, 4-bit keys roughly halve the per-layer attention-output error vs
+# 3-bit (~5% vs ~12% median with an fp16 sink+hot window) -- see
+# benchmarks/RESULTS_longbench.md. Values are far less sensitive and carry the
+# compression. Only the explicit ``extreme`` preset drops keys below 4-bit.
 
 _TARGETS: dict[str, dict] = {
     "quality": {
@@ -149,16 +156,17 @@ _TARGETS: dict[str, dict] = {
         "description": "Best quality/compression tradeoff (K4/V3 + RoPE boost)",
     },
     "compression": {
-        "key_bits": 3,
+        "key_bits": 4,
         "value_bits": 2,
         "rope_aware": True,
-        "description": "Maximum compression (K3/V2 + RoPE boost)",
+        "description": "Maximum compression at safe key quality (K4/V2 + RoPE boost)",
     },
     "extreme": {
         "key_bits": 2,
         "value_bits": 2,
         "rope_aware": False,
-        "description": "Extreme compression, lower quality (K2/V2)",
+        "description": "Extreme compression, lower quality (K2/V2; below the 4-bit "
+        "key default -- opt in knowingly)",
     },
 }
 


### PR DESCRIPTION
Keys are the sensitive side (softmax amplifies key-quant error); 4-bit halves attention error vs 3-bit on real Qwen2.5-7B. compression preset K3/V2 -> K4/V2; only extreme drops below 4-bit keys.