### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## v1.1.0
+
+### Added
+- **`ADCIndex`** — fast compressed-domain search (asymmetric-distance scan over the
+  packed codes). Optional AVX2 kernel (`turboquant_pro/_adc`, build with
+  `pip install turboquant-pro[fast]` + `python -m turboquant_pro._adc`) with a correct
+  numpy fallback. ~3700 qps at recall@10 0.9995 (7.9× over flat reconstruct).
+- **Fused KV-decode kernel** — `turboquant_pro.kv_kernel` (split-K CUDA flash-decode)
+  and `turboquant_pro.kv_fused` (reference + hot/cold online-softmax merge), wired into
+  `TurboQuantKVCache.fused_decode`. Beats decompress-then-attend up to 13× at 32k
+  context; exact to ≤4e-7.
+- **`PCAMatryoshka.suggest_output_dim`** — variance-aware truncation-dim selection.
+- **`turboquant_pro.format`** — TQE1 versioned, self-describing compressed-vector
+  container (`pack`/`unpack`/`pack_batch`/`unpack_batch`); spec in `docs/FORMAT_SPEC.md`.
+- Public ANN benchmarks across text **and vision** (GloVe-100, NYTimes-256,
+  deep-image-96) with honest scope; `COMPREHENSIVE_ANALYSIS.md`.
+
+### Changed
+- **AutoConfig defaults keys to 4-bit.** The `compression` preset moves K3/V2 → K4/V2.
+  Keys amplify quantization error through the attention softmax; 4-bit keys roughly
+  halve the per-layer attention error vs 3-bit on real Qwen2.5-7B activations
+  (`benchmarks/RESULTS_longbench.md`). Only `extreme` drops keys below 4-bit.
+- Corrected citations repo-wide against arXiv (TurboQuant 2504.19874, PolarQuant
+  2502.02617, QJL 2406.03482); removed a fabricated title.
+
+### Notes
+- The AVX2/CUDA kernels are optional accelerators with CPU/numpy fallbacks; the
+  pure-Python wheel installs everywhere.
+
+## v1.0.0
+- Learned codebook fine-tuning (`LearnedQuantizer`), multi-modal presets
+  (`ModalityPreset`), production observability (`QualityMonitor`).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Andrew H.
     email: andrew.bond@sjsu.edu
     affiliation: San Jose State University
-version: 0.3.0
+version: 1.1.0
 date-released: 2026-04-04
 license: MIT
 doi: "10.5281/zenodo.20660087"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ flowchart TB
     class HNSW,CACHE2,QM,EXP ops;
 ```
 
+## What's New in v1.1.0
+
+- **Fast compressed search** (`ADCIndex`): search the compact codes directly with an
+  asymmetric-distance scan — **0.9995 recall@10 at ~3700 qps** (7.9× over flat
+  reconstruct), via an optional AVX2 kernel (`turboquant_pro/_adc`) with a numpy
+  fallback. Beats 2024 SOTA (RaBitQ) on recall, validated on three public ANN
+  benchmarks across **text and vision** (GloVe, NYTimes, deep-image).
+- **Fused KV-decode kernel** (`TurboQuantKVCache.fused_decode`): one decode step over
+  the whole cache computed directly on the codes (no reconstruction) — a split-K CUDA
+  flash-decode that **beats decompress-then-attend up to 13× at 32k context**, exact
+  to ≤4e-7, with the fp16 hot-window merge.
+- **Variance-aware truncation** (`PCAMatryoshka.suggest_output_dim`): pick the PCA
+  rank from the data's spectrum (truncation only helps when variance is concentrated).
+- **Portable format** (`turboquant_pro.format`): TQE1, a versioned self-describing
+  container for compressed vectors.
+- **AutoConfig defaults keys to 4-bit** (compression preset K3/V2 → K4/V2): keys are
+  the sensitive side of attention; 4-bit halves the per-layer error vs 3-bit on real
+  Qwen2.5-7B activations.
+- **Citations corrected** against arXiv (TurboQuant 2504.19874, PolarQuant 2502.02617,
+  QJL 2406.03482).
+
 ## What's New in v1.0.0
 
 - **Learned codebook fine-tuning** (`LearnedQuantizer`): Train codebooks on your actual data instead of assuming Gaussian. `fit_codebook(embeddings)` returns a ready quantizer. Pushes cosine similarity from 0.978 to 0.99+ at the same bit-width.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "turboquant-pro"
-version = "1.0.0"
+version = "1.1.0"
 description = "PCA-Matryoshka + TurboQuant compression for embeddings, LLM KV caches, pgvector, and NATS — up to 27x compression"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
ADCIndex + AVX2 search kernel; fused KV-decode (TurboQuantKVCache.fused_decode, up to 13x); suggest_output_dim; TQE1 format; 3 public benchmarks (text+vision); AutoConfig 4-bit keys; citations fixed. CHANGELOG + What is New.