### PR TITLE
fix: add author ORCID to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,7 @@ authors:
     given-names: Andrew H.
     email: andrew.bond@sjsu.edu
     affiliation: San Jose State University
+    orcid: "https://orcid.org/0009-0003-2599-6158"
 version: 1.4.0
 date-released: 2026-06-29
 license: MIT


### PR DESCRIPTION
Adds the author ORCID (0009-0003-2599-6158) to CITATION.cff (was missing).