### PR TITLE
Address Review 2: version map, namespace disambiguation, CLAIMS.md

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -1,0 +1,42 @@
+# CLAIMS.md — what we claim, and exactly how to reproduce it
+
+At-a-glance claim → reproduction table. Every claim links to a runnable notebook under
+[`notebooks/claims/`](notebooks/claims). The **central result** is Track 1 (embedding compression +
+compressed-domain retrieval) — CPU/Colab-reproducible. Track 2 (KV-cache / fused decode) is the
+engineering-package extra and needs a GPU. Full detail + scope caveats: [`docs/claims.md`](docs/claims.md).
+
+**Status legend:** *Reproducible* = one *Run all* on public data reproduces the claim ·
+*Needs local run* = reproducible but full-scale/timing needs your hardware ·
+*Partial* = notebook runs, one variant left to fill in ·
+*Experimental* = requires GPU + model weights, treat as engineering/preview.
+
+## Track 1 — Embedding / vector-DB compression (central result)
+
+| Claim | Public reproduction? | Dataset | Command / notebook | Hardware | Status |
+|---|---|---|---|---|---|
+| **27× compression at high recall@10** (5× oversample + rerank) | Yes | GloVe-100-angular (public) | [`00_canonical_sota_embedding.ipynb`](notebooks/claims/00_canonical_sota_embedding.ipynb) | CPU | Reproducible |
+| **Beats RaBitQ on recall / ties OPQ, builds 4–20× faster** | Yes (full GloVe); 1M-scale timing local | GloVe-100-angular (1.18M) | [`00_canonical_sota_embedding.ipynb`](notebooks/claims/00_canonical_sota_embedding.ipynb) · [`benchmarks/canonical_embedding.py`](benchmarks/canonical_embedding.py) | CPU (GPU optional) | Reproducible (abs. build-time = local run) |
+| **PCA rotation makes non-Matryoshka models truncatable, no retraining** | Yes | GloVe-100-angular | [`01_pca_truncation.ipynb`](notebooks/claims/01_pca_truncation.ipynb) | CPU | Reproducible |
+| **Learned codebooks reduce quantization error ~22%** | Partially | GloVe-100-angular | [`02_learned_codebooks.ipynb`](notebooks/claims/02_learned_codebooks.ipynb) | CPU | Partial (learned-variant cell to fill) |
+| **ADCIndex compressed-domain search throughput** | Yes (recall); QPS local | GloVe-100-angular | [`03_adcindex_throughput.ipynb`](notebooks/claims/03_adcindex_throughput.ipynb) | CPU | Reproducible (abs. QPS = local run) |
+| **Up to 114× storage compression** | Yes (scoped) | dataset-dependent | operating point of [`00_...ipynb`](notebooks/claims/00_canonical_sota_embedding.ipynb) | CPU | Reproducible (storage-only, recall via rerank) |
+
+> **Honest scope.** PCA *truncation* wins only for high-dimensional / concentrated-spectrum
+> embeddings (sentence, vision). On compact descriptor sets (GloVe-100, NYTimes-256) it loses to
+> PQ/OPQ; at full dimension / matched bytes the TurboQuant scalar quantizer still **wins on GloVe and
+> vision, ties on NYTimes** — see [`benchmarks/RESULTS_glove.md`](benchmarks/RESULTS_glove.md).
+
+## Track 2 — KV-cache compression (engineering package; GPU)
+
+| Claim | Public reproduction? | Dataset | Command / notebook | Hardware | Status |
+|---|---|---|---|---|---|
+| **KV *keys* need per-channel / asym treatment** (incl. Qwen2.5 collapse & recovery) | Yes (on GPU) | Llama / Mistral / Qwen + perplexity/LongBench | [`10_kv_keys_per_channel.ipynb`](notebooks/claims/10_kv_keys_per_channel.ipynb) · [`docs/KV_KEYS_FINDING.md`](docs/KV_KEYS_FINDING.md) | GPU | Experimental |
+| **NF4 / asym-NF4 vs uniform K4** across model families | Yes (on GPU) | Llama / Mistral / Qwen | [`11_kv_nf4_matrix.ipynb`](notebooks/claims/11_kv_nf4_matrix.ipynb) · [`benchmarks/RESULTS_longbench.md`](benchmarks/RESULTS_longbench.md) | GPU | Experimental |
+| **Comparison vs KVQuant** on LongBench/perplexity | Partially | model + task | [`12_kv_vs_kvquant.ipynb`](notebooks/claims/12_kv_vs_kvquant.ipynb) | GPU | Experimental (our KVQuant reimpl. not a faithful repro of their strongest number) |
+| **Fused decode kernel speedup** | Yes (on GPU) | microbenchmark | [`benchmarks/benchmark_kv_kernel.py`](benchmarks/benchmark_kv_kernel.py) | GPU + build toolchain | Experimental |
+
+---
+
+*The bytes/vector figures are computed analytically (`out_dim × bits ÷ 8`), not via
+`estimate_storage()`, which currently misreports fixed 1024→384 dims — see
+[`docs/claims.md`](docs/claims.md). Notebooks ship with empty outputs; numbers appear when you run them.*

--- a/README.md
+++ b/README.md
@@ -13,7 +13,27 @@
 
 Up to 27× embedding compression at 99.8% recall@10 (with 5× oversampling + reranking — all methods benchmarked identically). At ~30× compression turboquant-pro beats the 2024 SOTA (RaBitQ) on recall and ties OPQ at 1M-vector scale, while building the index 4–20× faster. Learned codebooks reduce quantization error 22%. Multi-modal (text, vision, audio, code), production observability, runs on consumer GPUs (Volta+) and CPU. (Test count: see the CI badge above.)
 
-> **What this is — two contributions in one toolkit.** (1) *Embedding / vector-DB compression*: PCA-reordered dimensions + scalar quantization for high-recall compressed retrieval. (2) *KV-cache compression*: architecture-aware, per-channel / asymmetric treatment of attention **keys** (generic vector-reconstruction metrics are actively misleading for keys). The two tracks share code but are evaluated differently — retrieval metrics (recall@k, QPS, build time) vs. generation metrics (perplexity, LongBench). See [`docs/claims.md`](docs/claims.md) for the evidence ladder and [`docs/api-stability.md`](docs/api-stability.md) for stability tiers.
+> **What this is — two contributions in one toolkit.** (1) *Embedding / vector-DB compression*: PCA-reordered dimensions + scalar quantization for high-recall compressed retrieval. (2) *KV-cache compression*: architecture-aware, per-channel / asymmetric treatment of attention **keys** (generic vector-reconstruction metrics are actively misleading for keys). The two tracks share code but are evaluated differently — retrieval metrics (recall@k, QPS, build time) vs. generation metrics (perplexity, LongBench). The **central, most-validated result is embedding compression + compressed-domain retrieval** (Track 1); KV-cache and fused decode (Track 2) are the engineering-package extras. See **[`CLAIMS.md`](CLAIMS.md)** for the at-a-glance claim/reproduction table, [`docs/claims.md`](docs/claims.md) for the detailed evidence ladder, and [`docs/api-stability.md`](docs/api-stability.md) for stability tiers.
+
+### Version map
+| Artifact | Version / ref |
+|---|---|
+| Latest PyPI release | **1.4.0** |
+| Current GitHub docs / `main` | **1.4.0** (+ post-1.4.0 reproduction notebooks on `master`) |
+| Public benchmark notebooks (`notebooks/`, `notebooks/claims/`) | compatible with **1.4.0** |
+| Paper / archival artifact | release tag [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087) |
+
+GitHub's older public crawl may still surface **v1.1.0**; the canonical artifact is **v1.4.0** (PyPI + latest release + docs).
+
+### Not to be confused with
+`turboquant-pro` is distinct from the similarly-named `turboquant`, `pyturboquant`, `turboquant-py`, `turboquant-ml`, and `turboquant_plus`. **Uniquely, `turboquant-pro` provides PCA-Matryoshka embedding compression plus production-oriented compressed-domain search and integrations (FAISS, pgvector, HNSW, ADCIndex), with architecture-aware KV-cache quantization as a separate module** — not just the original TurboQuant vector/KV-cache quantizer.
+
+### API stability (summary — full table in [`docs/api-stability.md`](docs/api-stability.md))
+| Tier | Components |
+|---|---|
+| **Stable** | `PCAMatryoshka`, embedding compression pipeline, basic `TurboQuantKV`, TQE1 format |
+| **Beta** | `ADCIndex`, `TurboQuantKVCache`, FAISS / pgvector wrappers |
+| **Experimental** | CUDA fused decode, vLLM manager, model-weight compressor, PostgreSQL extension, NATS transport |
 
 > **Evaluate on the metric that matters.** Cosine similarity to the original vector is *not* a reliable proxy for downstream quality — for retrieval it diverges from recall at high compression, and for KV-cache **keys** it is actively misleading (see [v1.2.0 below](#highlights)). Always measure recall (retrieval) or perplexity (generation).
 

--- a/REVIEW_RESPONSE_2.md
+++ b/REVIEW_RESPONSE_2.md
@@ -1,0 +1,40 @@
+# Response to Review 2 — positioning & discoverability
+
+Review 2 raised five remaining issues, all about **presentation, versioning, and disambiguation**
+(no correctness concerns). All five addressed:
+
+**1. Inconsistent versioning (GitHub crawl shows v1.1.0, PyPI at v1.4.0). ✎ (done)**
+Added a **Version map** table near the top of the README: latest PyPI **1.4.0**, GitHub docs/`main`
+**1.4.0** (+ post-1.4.0 reproduction notebooks on `master`), benchmark notebooks compatible with
+1.4.0, paper/archival artifact = tag `v1.4.0` + Zenodo DOI. Explicit note that the canonical artifact
+is v1.4.0 and any v1.1.0 the crawl surfaces is stale.
+- *Recommendation (needs author):* cut a **v1.4.1** release so the `notebooks/claims/` reproduction
+  suite ships in a tagged artifact (they currently live on `master`, post-v1.4.0).
+
+**2. Broad tool surface → API stability table. ✎ (done)**
+Added a compact **API stability** table (Stable / Beta / Experimental) directly in the README,
+linking the full [`docs/api-stability.md`](docs/api-stability.md). (The doc existed from Review 1;
+Review 2 asked for it to be visible in the README itself — now it is.)
+
+**3. Crowded namespace (turboquant, pyturboquant, turboquant-py, turboquant-ml, turboquant_plus). ✎ (done)**
+Added a **"Not to be confused with"** block naming the lookalikes and stating what `turboquant-pro`
+**uniquely** does: PCA-Matryoshka embedding compression + production-oriented compressed-domain search
+and integrations (FAISS, pgvector, HNSW, ADCIndex), with architecture-aware KV-cache quantization as a
+separate module.
+
+**4. Make the claim hierarchy impossible to miss → CLAIMS.md. ✎ (done)**
+Added a top-level **[`CLAIMS.md`](CLAIMS.md)** in exactly the requested schema —
+*Claim / Public reproduction? / Dataset / Command-or-notebook / Hardware / Status* — split into
+Track 1 (central, CPU-reproducible) and Track 2 (GPU, experimental). Linked from the README intro;
+`docs/claims.md` now cross-references it as the detailed version.
+
+**5. Tighten paper/repo distinction. ✎ (done)**
+The README two-contribution block now states plainly that the **central, most-validated result is
+embedding compression + compressed-domain retrieval (Track 1)**, with KV-cache and fused decode
+(Track 2) as the engineering-package extras. CLAIMS.md reinforces the same split. This gives a
+reviewer one central result to validate rather than a whole platform.
+
+## Still needs the author (outside the repo)
+- Update the **GitHub "About"** blurb / repo social preview if it still emphasizes v1.1.0 or an old
+  test count.
+- Optionally cut **v1.4.1** to tag the reproduction notebooks into a release artifact.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1,5 +1,9 @@
 # Claims & evidence ladder
 
+> For the **at-a-glance claim → reproduction table** (Claim / Public reproduction? / Dataset /
+> Command / Hardware / Status), see **[`CLAIMS.md`](../CLAIMS.md)** at the repo root. This page is the
+> detailed version with evidence levels and scope caveats.
+
 Every headline claim in this project sits at one of five evidence levels, and **each rung links to a
 runnable notebook** under [`notebooks/claims/`](../notebooks/claims). The two tracks —
 **embedding/vector-DB compression** and **KV-cache compression** — are evaluated with entirely


### PR DESCRIPTION
Addresses reviewer report 2 (`Documents/turboquant-pro-review-2.txt`) — all five points are presentation/positioning, no correctness changes.

1. **Version map** near top of README (PyPI 1.4.0 / docs 1.4.0 / notebooks 1.4.0-compatible / artifact tag `v1.4.0` + Zenodo DOI); notes any v1.1.0 crawl is stale.
2. **API stability table** (Stable/Beta/Experimental) surfaced inline in the README, linking `docs/api-stability.md`.
3. **"Not to be confused with"** block disambiguating from `turboquant` / `pyturboquant` / `turboquant-py` / `turboquant-ml` / `turboquant_plus`, stating what turboquant-pro uniquely does.
4. **`CLAIMS.md`** (new, repo root) in the reviewer's exact schema — Claim / Public reproduction? / Dataset / Command-or-notebook / Hardware / Status — split Track 1 (central, CPU) vs Track 2 (GPU, experimental). Linked from README; `docs/claims.md` cross-references it.
5. **Paper/package split made explicit**: Track 1 (embedding compression + compressed-domain retrieval) is the central validated result; Track 2 (KV-cache, fused decode) is the engineering extra.

`REVIEW_RESPONSE_2.md` has the point-by-point. Two items remain for the author outside the repo: update the GitHub "About"/social preview, and optionally cut **v1.4.1** to tag the reproduction notebooks into a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)