### PR TITLE
Address Review 3: version block, vLLM disambiguation, claims-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,29 @@
 
 **PCA-Matryoshka dimension reduction + TurboQuant scalar quantization for embedding compression, LLM KV caches, model weight pruning, pgvector, FAISS, and NATS transport.**
 
-Up to 27× embedding compression at 99.8% recall@10 (with 5× oversampling + reranking — all methods benchmarked identically). At ~30× compression turboquant-pro beats the 2024 SOTA (RaBitQ) on recall and ties OPQ at 1M-vector scale, while building the index 4–20× faster. Learned codebooks reduce quantization error 22%. Multi-modal (text, vision, audio, code), production observability, runs on consumer GPUs (Volta+) and CPU. (Test count: see the CI badge above.)
+Up to **27× embedding compression** at high recall, competitive with the 2024 SOTA (RaBitQ / OPQ) via compressed-domain retrieval. Multi-modal (text, vision, audio, code), production observability, runs on consumer GPUs (Volta+) and CPU.
+
+> **Every headline number — with its reproduction status.** Rather than list claims here, each one (27× compression, RaBitQ/OPQ comparison, 4–20× faster builds, 22% learned-codebook error reduction, KV-cache results) is in **[`CLAIMS.md`](CLAIMS.md)** as a table row: dataset, one-click notebook, hardware, and whether it's CPU-reproducible or GPU-experimental. Test count: see the CI badge above (not a static number).
 
 > **What this is — two contributions in one toolkit.** (1) *Embedding / vector-DB compression*: PCA-reordered dimensions + scalar quantization for high-recall compressed retrieval. (2) *KV-cache compression*: architecture-aware, per-channel / asymmetric treatment of attention **keys** (generic vector-reconstruction metrics are actively misleading for keys). The two tracks share code but are evaluated differently — retrieval metrics (recall@k, QPS, build time) vs. generation metrics (perplexity, LongBench). The **central, most-validated result is embedding compression + compressed-domain retrieval** (Track 1); KV-cache and fused decode (Track 2) are the engineering-package extras. See **[`CLAIMS.md`](CLAIMS.md)** for the at-a-glance claim/reproduction table, [`docs/claims.md`](docs/claims.md) for the detailed evidence ladder, and [`docs/api-stability.md`](docs/api-stability.md) for stability tiers.
 
-### Version map
-| Artifact | Version / ref |
-|---|---|
-| Latest PyPI release | **1.4.0** |
-| Current GitHub docs / `main` | **1.4.0** (+ post-1.4.0 reproduction notebooks on `master`) |
-| Public benchmark notebooks (`notebooks/`, `notebooks/claims/`) | compatible with **1.4.0** |
-| Paper / archival artifact | release tag [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087) |
+### Version
 
-GitHub's older public crawl may still surface **v1.1.0**; the canonical artifact is **v1.4.0** (PyPI + latest release + docs).
+```
+Current package:               turboquant-pro 1.4.0
+Current paper artifact:        v1.4.0 / commit 1f39747
+Main public benchmark notebook: compatible with 1.4.0
+Earlier v1.1.0 docs are retained for release history only.
+```
+
+Artifact tag [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087). A stale public crawl may still surface **v1.1.0** language — the canonical version is **1.4.0** everywhere (PyPI, latest release, docs); v1.1.0 appears only as a row in the [release history](#library-growth).
 
 ### Not to be confused with
-`turboquant-pro` is distinct from the similarly-named `turboquant`, `pyturboquant`, `turboquant-py`, `turboquant-ml`, and `turboquant_plus`. **Uniquely, `turboquant-pro` provides PCA-Matryoshka embedding compression plus production-oriented compressed-domain search and integrations (FAISS, pgvector, HNSW, ADCIndex), with architecture-aware KV-cache quantization as a separate module** — not just the original TurboQuant vector/KV-cache quantizer.
+`turboquant-pro` is distinct from the similarly-named `turboquant`, `pyturboquant`, `turboquant-ml`, `turboquant-py`, `turboquant_plus`, and **vLLM's own TurboQuant integration**.
+
+> **`turboquant-pro` is not just a KV-cache TurboQuant implementation.** It is a **PCA-Matryoshka + TurboQuant toolkit for compressed embedding retrieval**, with additional KV-cache, vector-database (FAISS, pgvector, HNSW, ADCIndex), and systems integrations.
+
+Those other packages focus mainly on the original TurboQuant vector/KV-cache quantizer; here that quantizer is one component of a broader, retrieval-first toolkit.
 
 ### API stability (summary — full table in [`docs/api-stability.md`](docs/api-stability.md))
 | Tier | Components |

--- a/REVIEW_RESPONSE_3.md
+++ b/REVIEW_RESPONSE_3.md
@@ -1,0 +1,41 @@
+# Response to Review 3 — version consistency & PyPI-page positioning
+
+Three remaining issues, all presentation:
+
+**1. Version consistency (PyPI 1.4.0 vs stale v1.1.0 crawl). ✎ (done)**
+Replaced the version table with the reviewer's exact top-of-README block, artifact commit filled in:
+
+```
+Current package:               turboquant-pro 1.4.0
+Current paper artifact:        v1.4.0 / commit 1f39747
+Main public benchmark notebook: compatible with 1.4.0
+Earlier v1.1.0 docs are retained for release history only.
+```
+
+Verified the repo itself is already consistent — README and `CHANGELOG.md` both lead with **v1.4.0**;
+the only `v1.1.0` occurrences are the legitimate release-history table row and changelog section. So
+the "v1.1.0 in several places" the reviewer saw is **stale search indexing**, not a repo error. The
+block makes that explicit and the row now says it's retained for history only.
+- *Root cause of the stale PyPI text (incl. "489 tests"): PyPI serves the README of the **last
+  published release** (1.4.0), which predates these edits. It only refreshes on the next `twine
+  upload`.* → cut **v1.4.1** (see below).
+
+**2. Name collision / positioning. ✎ (done)**
+Added **vLLM's own TurboQuant integration** to the "Not to be confused with" list (alongside
+`turboquant`, `pyturboquant`, `turboquant-ml`, `turboquant-py`, `turboquant_plus`) and adopted the
+reviewer's exact framing: *"turboquant-pro is not just a KV-cache TurboQuant implementation. It is a
+PCA-Matryoshka + TurboQuant toolkit for compressed embedding retrieval, with additional KV-cache,
+vector-database, and systems integrations."*
+
+**3. Dense high-impact claims paragraph → claims table. ✎ (done)**
+Trimmed the README headline paragraph to a short lede; the full claim list (27×, RaBitQ/OPQ, 4–20×
+builds, 22% codebooks, KV-cache) now lives **only** in the [`CLAIMS.md`](CLAIMS.md) table with
+per-claim dataset / notebook / hardware / reproduction status. Removed the static test count in favour
+of the CI badge (already done in Review 1; the PyPI copy will refresh on the next release).
+
+## Needs the author (outside the repo)
+- **Cut `v1.4.1`** (or `v1.5.0`) and `twine upload` so the **PyPI page** picks up the slimmed claims
+  paragraph, the removed "489 tests", and ships the `notebooks/claims/` reproduction suite in a tagged
+  artifact. This is the single action that resolves the externally-visible staleness the reviewer keeps
+  seeing. I can prep the release notes + tag on request.
+- Refresh the **GitHub "About"/social preview** if it still shows old text.


### PR DESCRIPTION
Addresses reviewer report 3 — three presentation issues, no correctness changes.

1. **Version consistency.** README **Version** block in the reviewer's exact wording, artifact commit filled in (`v1.4.0 / commit 1f39747`), "earlier v1.1.0 docs retained for release history only." Repo is already consistent (README + CHANGELOG lead with 1.4.0; v1.1.0 only in the release-history row) — the stale v1.1.0 the crawl shows is search indexing.
2. **Name collision / positioning.** Added **vLLM's own TurboQuant integration** to "Not to be confused with" and adopted the exact framing: *turboquant-pro is not just a KV-cache TurboQuant implementation — it is a PCA-Matryoshka + TurboQuant toolkit for compressed embedding retrieval, with additional KV-cache, vector-database, and systems integrations.*
3. **Dense claims paragraph → table.** Trimmed the headline paragraph to a short lede; the full claim list now lives only in [`CLAIMS.md`](CLAIMS.md) with per-claim reproduction status. Static test count already replaced by the CI badge.

**Note:** the externally-visible PyPI staleness (incl. "489 tests") is the *last-published release's* README; it refreshes on the next `twine upload`. Recommend cutting **v1.4.1** — happy to prep notes + tag. Full point-by-point in `REVIEW_RESPONSE_3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)