### PR TITLE
Version coherence: CITATION.cff -> 1.4.1 + sharpen HF-turboquant distinction

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     email: andrew.bond@sjsu.edu
     affiliation: San Jose State University
     orcid: "https://orcid.org/0009-0003-2599-6158"
-version: 1.4.0
-date-released: 2026-06-29
+version: 1.4.1
+date-released: 2026-07-04
 license: MIT
 doi: "10.5281/zenodo.20660087"
 url: "https://github.com/ahb-sjsu/turboquant-pro"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Package [`v1.4.1`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.
 
 > **`turboquant-pro` is not just a KV-cache TurboQuant implementation.** It is a **PCA-Matryoshka + TurboQuant toolkit for compressed embedding retrieval**, with additional KV-cache, vector-database (FAISS, pgvector, HNSW, ADCIndex), and systems integrations.
 
-Those other packages focus mainly on the original TurboQuant vector/KV-cache quantizer; here that quantizer is one component of a broader, retrieval-first toolkit.
+In particular, it is **distinct from the `turboquant` package focused on HuggingFace KV-cache compression** (an implementation of the Google/ICLR *TurboQuant* KV-cache algorithm). The original TurboQuant paper ([Zandieh et al., ICLR 2026](https://arxiv.org/abs/2504.19874)) is about *online vector quantization with near-optimal distortion rate*; here that quantizer is **one component** of a broader, retrieval-first toolkit — the headline contribution is PCA-Matryoshka compressed embedding retrieval, with KV-cache and systems integrations alongside it.
 
 ### API stability (summary — full table in [`docs/api-stability.md`](docs/api-stability.md))
 | Tier | Components |


### PR DESCRIPTION
Addresses the latest review's "version coherence" point.

**Real fix found:** `CITATION.cff` was left at **1.4.0** (date 2026-06-29) after the 1.4.1 release — that's the genuine mismatch. Now all four current-version declarations agree at **1.4.1**: `pyproject.toml`, `turboquant_pro/__init__.py`, `CITATION.cff`, and PyPI. GitHub's "Cite this repository" widget reads CITATION from the default branch, so this fixes it immediately.

**The "v1.1.0" the reviewer sees is stale crawl**, not repo state: no current file declares 1.1.0 (grep-verified); it's GitHub search indexing the historical "Release v1.1.0" commit. The new 1.4.1 activity + this commit should push it down.

**Sharpened disambiguation** with the reviewer's exact framing: turboquant-pro is distinct from the `turboquant` package focused on HuggingFace KV-cache compression (the Google/ICLR TurboQuant KV-cache algorithm); the original TurboQuant paper is about online vector quantization — here that quantizer is one component of a retrieval-first toolkit.

**Already shipped in 1.4.1** (the review was written against a pre-1.4.1 cache): the top-of-README Version block, `CLAIMS.md` (Claim / Public reproduction / Artifact / Hardware / Status), and the core-vs-experimental split. All live on PyPI 1.4.1 now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)