### PR TITLE
Release v1.4.2 — version coherence + HF-turboquant disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.4.2
+
+Version-coherence and positioning patch (no library API changes).
+
+### Fixed
+- **Version coherence.** `CITATION.cff` was left at 1.4.0 after the 1.4.1 release; all current-version
+  declarations now agree (`pyproject.toml`, `turboquant_pro/__init__.py`, `CITATION.cff`, PyPI). The
+  "v1.1.0" seen in some search crawls is stale indexing of the historical "Release v1.1.0" commit — no
+  current file declares 1.1.0.
+
+### Changed
+- README "Not to be confused with" states plainly that turboquant-pro is **distinct from the
+  `turboquant` package focused on HuggingFace KV-cache compression** (the Google/ICLR TurboQuant
+  KV-cache algorithm); the original TurboQuant paper is about online vector quantization, and here that
+  quantizer is one component of a retrieval-first toolkit.
+
 ## v1.4.1
 
 Documentation, reproducibility, and positioning release (no library API changes) — publishes the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
     email: andrew.bond@sjsu.edu
     affiliation: San Jose State University
     orcid: "https://orcid.org/0009-0003-2599-6158"
-version: 1.4.1
+version: 1.4.2
 date-released: 2026-07-04
 license: MIT
 doi: "10.5281/zenodo.20660087"

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Up to **27× embedding compression** at high recall, competitive with the 2024 S
 ### Version
 
 ```
-Current package:               turboquant-pro 1.4.1
+Current package:               turboquant-pro 1.4.2
 Paper / archival artifact:     v1.4.0 / commit 1f39747 (DOI 10.5281/zenodo.20660087)
 Main public benchmark notebook: compatible with 1.4.x
 Earlier v1.1.0 docs are retained for release history only.
 ```
 
-Package [`v1.4.1`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.1) is a docs + reproducibility release; the DOI-archived core-results artifact remains [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087). A stale public crawl may still surface **v1.1.0** language — the canonical version is **1.4.x** everywhere (PyPI, latest release, docs); v1.1.0 appears only as a row in the [release history](#library-growth).
+Package [`v1.4.2`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.2) is the current docs + reproducibility release; the DOI-archived core-results artifact remains [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087). A stale public crawl may still surface **v1.1.0** language — the canonical version is **1.4.x** everywhere (PyPI, latest release, docs); v1.1.0 appears only as a row in the [release history](#library-growth).
 
 ### Not to be confused with
 `turboquant-pro` is distinct from the similarly-named `turboquant`, `pyturboquant`, `turboquant-ml`, `turboquant-py`, `turboquant_plus`, and **vLLM's own TurboQuant integration**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "turboquant-pro"
-version = "1.4.1"
+version = "1.4.2"
 description = "PCA-Matryoshka + TurboQuant compression for embeddings, LLM KV caches, pgvector, and NATS — up to 27x compression"
 readme = "README.md"
 license = {text = "MIT"}

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -138,4 +138,4 @@ try:
     )
 except Exception:
     pass
-__version__ = "1.4.1"
+__version__ = "1.4.2"


### PR DESCRIPTION
Publishes the CITATION.cff coherence fix (all version declarations now agree at 1.4.2) and the sharpened `turboquant` (HuggingFace KV-cache) disambiguation to PyPI. No library API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)