### PR TITLE
docs: remove meta-commentary from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Up to **27× embedding compression** at high recall, competitive with the 2024 SOTA (RaBitQ / OPQ) via compressed-domain retrieval. Multi-modal (text, vision, audio, code), production observability, runs on consumer GPUs (Volta+) and CPU.
 
-> **Every headline number — with its reproduction status.** Rather than list claims here, each one (27× compression, RaBitQ/OPQ comparison, 4–20× faster builds, 22% learned-codebook error reduction, KV-cache results) is in **[`CLAIMS.md`](CLAIMS.md)** as a table row: dataset, one-click notebook, hardware, and whether it's CPU-reproducible or GPU-experimental. Test count: see the CI badge above (not a static number).
+> **Every headline number — with its reproduction status — is in [`CLAIMS.md`](CLAIMS.md)** as a table row: claim, dataset, one-click notebook, hardware, and whether it's CPU-reproducible or GPU-experimental (27× compression, RaBitQ/OPQ comparison, 4–20× faster builds, 22% learned-codebook error reduction, KV-cache results). Test count: see the CI badge above.
 
 > **What this is — two contributions in one toolkit.** (1) *Embedding / vector-DB compression*: PCA-reordered dimensions + scalar quantization for high-recall compressed retrieval. (2) *KV-cache compression*: architecture-aware, per-channel / asymmetric treatment of attention **keys** (generic vector-reconstruction metrics are actively misleading for keys). The two tracks share code but are evaluated differently — retrieval metrics (recall@k, QPS, build time) vs. generation metrics (perplexity, LongBench). The **central, most-validated result is embedding compression + compressed-domain retrieval** (Track 1); KV-cache and fused decode (Track 2) are the engineering-package extras. See **[`CLAIMS.md`](CLAIMS.md)** for the at-a-glance claim/reproduction table, [`docs/claims.md`](docs/claims.md) for the detailed evidence ladder, and [`docs/api-stability.md`](docs/api-stability.md) for stability tiers.
 
@@ -23,10 +23,9 @@ Up to **27× embedding compression** at high recall, competitive with the 2024 S
 Current package:               turboquant-pro 1.4.2
 Paper / archival artifact:     v1.4.0 / commit 1f39747 (DOI 10.5281/zenodo.20660087)
 Main public benchmark notebook: compatible with 1.4.x
-Earlier v1.1.0 docs are retained for release history only.
 ```
 
-Package [`v1.4.2`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.2) is the current docs + reproducibility release; the DOI-archived core-results artifact remains [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087). A stale public crawl may still surface **v1.1.0** language — the canonical version is **1.4.x** everywhere (PyPI, latest release, docs); v1.1.0 appears only as a row in the [release history](#library-growth).
+Package [`v1.4.2`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.2) is the current release; the DOI-archived core-results artifact is [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087).
 
 ### Not to be confused with
 `turboquant-pro` is distinct from the similarly-named `turboquant`, `pyturboquant`, `turboquant-ml`, `turboquant-py`, `turboquant_plus`, and **vLLM's own TurboQuant integration**.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -28,7 +28,7 @@ apples-to-apples. Notebooks ship with empty outputs: numbers appear only when yo
 
 | Claim | Level | Reproduce (click to run) |
 |---|:--:|---|
-| **Beats RaBitQ on recall / ties OPQ at scale, builds index 4–20× faster** — the headline reviewers try first | L2 | **[`00_canonical_sota_embedding.ipynb`](../notebooks/claims/00_canonical_sota_embedding.ipynb)** — one table: flat / PQ / OPQ / IVFPQ / RaBitQ / PCA-only / TQ-only / PCA+TQ / ADCIndex, identical rerank, on public GloVe. |
+| **Beats RaBitQ on recall / ties OPQ at scale, builds index 4–20× faster** — the headline result | L2 | **[`00_canonical_sota_embedding.ipynb`](../notebooks/claims/00_canonical_sota_embedding.ipynb)** — one table: flat / PQ / OPQ / IVFPQ / RaBitQ / PCA-only / TQ-only / PCA+TQ / ADCIndex, identical rerank, on public GloVe. |
 | **27× storage compression @ high recall@10** (5× oversampling + reranking; all methods benchmarked identically) | L2 | Same notebook — read the compression×/recall columns at your operating point. |
 | **PCA rotation makes non-Matryoshka models truncatable, no retraining** (Varici et al. 2025) | L1 | **[`01_pca_truncation.ipynb`](../notebooks/claims/01_pca_truncation.ipynb)** — naive vs PCA truncation + retained variance, CPU-only. |
 | **Learned codebooks reduce quantization error ~22%** | L2 | **[`02_learned_codebooks.ipynb`](../notebooks/claims/02_learned_codebooks.ipynb)** — learned vs fixed reconstruction MSE at matched bits. |
@@ -60,8 +60,8 @@ apples-to-apples. Notebooks ship with empty outputs: numbers appear only when yo
 
 - Each row's level says *what kind* of evidence backs the claim, so you can decide whether it meets
   your bar before depending on it. **L4/L5 is not a weakness** — it is a disclosure.
-- The **strongest, most-scrutinized** claims (the RaBitQ/OPQ comparison; the KV-key finding) are the
-  ones wired to a single *Run all* — that was the top ask from Review 1.
+- The **strongest, most-scrutinized** claims (the RaBitQ/OPQ comparison; the KV-key finding) are
+  wired to a single *Run all*.
 - Stability of the *code* behind each claim is a separate axis — see
   [`docs/api-stability.md`](api-stability.md).
 

--- a/notebooks/claims/00_canonical_sota_embedding.ipynb
+++ b/notebooks/claims/00_canonical_sota_embedding.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "**Evidence-ladder rung:** Track 1 \u00b7 the flagship claim \u2014 *beats RaBitQ on recall, ties OPQ at scale, builds faster* (docs/claims.md).\n",
     "\n",
-    "ONE table, ALL methods, IDENTICAL rerank protocol, on a **public** ann-benchmarks dataset scored against its **provided** ground-truth neighbours. This is the claim reviewers will try to reproduce first \u2014 so it is one *Run all* away.\n",
+    "ONE table, ALL methods, IDENTICAL rerank protocol, on a **public** ann-benchmarks dataset scored against its **provided** ground-truth neighbours \u2014 the flagship result, one *Run all* away.\n",
     "\n",
     "> **Honest scope (see `benchmarks/RESULTS_glove.md`).** PCA *truncation* wins only for high-dimensional embeddings with a concentrated spectrum (sentence/vision encoders). On already-compact descriptor sets like GloVe-100 it discards real variance and loses; at **full dimension / matched bytes** the TurboQuant scalar quantizer still wins or ties PQ/OPQ. This notebook reproduces that full picture, not a cherry-pick."
    ]

--- a/notebooks/claims/04_ood_anisotropic.ipynb
+++ b/notebooks/claims/04_ood_anisotropic.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# OOD stress test \u2014 anisotropic / heavy-tailed embeddings \u2014 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ahb-sjsu/turboquant-pro/blob/master/notebooks/claims/04_ood_anisotropic.ipynb)\n",
     "\n",
-    "**Evidence-ladder rung:** Track 1 \u00b7 L1 (Colab). Robustness check requested in review: public sets (GloVe, LaBSE) are relatively well-behaved, but heavily fine-tuned domain encoders (biomedical, legal) can have **extreme spatial anisotropy** and non-Gaussian rotated tails.\n",
+    "**Evidence-ladder rung:** Track 1 \u00b7 L1 (Colab). Robustness check: public sets (GloVe, LaBSE) are relatively well-behaved, but heavily fine-tuned domain encoders (biomedical, legal) can have **extreme spatial anisotropy** and non-Gaussian rotated tails.\n",
     "\n",
     "We synthesize a pathological corpus \u2014 a few dominant directions (rank-deficient core), a **power-law eigenvalue spectrum**, Student-t heavy tails, and a random rotation \u2014 and run the same canonical ladder against exact ground truth. The question: does PCA+TQ degrade gracefully, and does the honest dataset-dependence story still hold?"
    ]

--- a/notebooks/claims/_gen_notebooks.py
+++ b/notebooks/claims/_gen_notebooks.py
@@ -110,8 +110,8 @@ def build_flagship():
            "ties OPQ at scale, builds faster* (docs/claims.md).",
            "",
            "ONE table, ALL methods, IDENTICAL rerank protocol, on a **public** ann-benchmarks "
-           "dataset scored against its **provided** ground-truth neighbours. This is the claim "
-           "reviewers will try to reproduce first — so it is one *Run all* away.",
+           "dataset scored against its **provided** ground-truth neighbours — the flagship result, "
+           "one *Run all* away.",
            "",
            "> **Honest scope (see `benchmarks/RESULTS_glove.md`).** PCA *truncation* wins only "
            "for high-dimensional embeddings with a concentrated spectrum (sentence/vision "
@@ -320,7 +320,7 @@ def build_ood_anisotropic():
     cells = [
         md(f"# OOD stress test — anisotropic / heavy-tailed embeddings — {colab_badge(rel)}",
            "",
-           "**Evidence-ladder rung:** Track 1 · L1 (Colab). Robustness check requested in review: "
+           "**Evidence-ladder rung:** Track 1 · L1 (Colab). Robustness check: "
            "public sets (GloVe, LaBSE) are relatively well-behaved, but heavily fine-tuned domain "
            "encoders (biomedical, legal) can have **extreme spatial anisotropy** and non-Gaussian "
            "rotated tails.",


### PR DESCRIPTION
Strips text that comments on the repo's own release history / search indexing / review process rather than describing the software — e.g. the "stale public crawl may still surface v1.1.0" sentence. Covers README (Version block + CLAIMS pointer), docs/claims.md, and the notebook generator (00, 04 regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)