### PR TITLE
rope_aware_k: protect DC-frequency W^K rows in weight quantization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **`ModelCompressor.quantize_weights(rope_aware_k=True)`** — weight PTQ
+  (uniform symmetric per-output-channel absmax over FFN + attention Linears)
+  with the §2.3 mechanism of
+  `docs/notes/projection_sensitivity_deconfounded.md` wired in as the
+  default: the long-wavelength (DC) RoPE rows of `W^K` — read from the
+  model's own `inv_freq` buffer (rope_scaling included), `rope_theta`
+  fallback — are kept full-precision (`k_protect_bits=8` for mixed-precision
+  instead). Measured basis: at 3-bit on Llama-3.2-3B, protecting the longest
+  octile (12.5% of K rows, ~0.4% of attention weights) recovers 87% of the
+  functional damage; the coupling replicates at 25× smaller amplitude on
+  Mistral-7B. Helpers `rope_protected_rows` / `quantize_weight_rows`
+  exported from `model_compress`; graceful degrade (warning, no protection)
+  for non-rotary models. Incident → instrument, weight-space edition.
+
 ## 1.7.0 — 2026-07-15
 
 Operator-dependent quantization for hybrid / state-space architectures: the

--- a/docs/notes/projection_sensitivity_deconfounded.md
+++ b/docs/notes/projection_sensitivity_deconfounded.md
@@ -338,6 +338,12 @@ cosine.
    behavioral probe; the matched-bit result argues for protecting **V/O** weights
    (not Q/K) under weight PTQ — inverse of the KV-cache key rule, exactly because
    it is the inverse operator.
+3. *(shipped)* The §2.3 mechanism is wired into the weight path:
+   `ModelCompressor.quantize_weights(bits, rope_aware_k=True)` quantizes FFN +
+   attention weights per output channel while keeping the long-wavelength RoPE
+   rows of `W^K` in full precision (or at `k_protect_bits`), with the protected
+   set read from the model's own `inv_freq` buffer. Default `k_protect_frac`
+   is 0.125 — the measured 87%-recovery octile.
 
 ---
 

--- a/tests/test_rope_aware_k.py
+++ b/tests/test_rope_aware_k.py
@@ -1,0 +1,180 @@
+"""
+Tests for RoPE-aware weight quantization in ModelCompressor (the section-2.3
+mechanism of docs/notes/projection_sensitivity_deconfounded.md: protect the
+long-wavelength (DC) rows of W^K instead of giving K more bits everywhere).
+
+Usage:
+    pytest tests/test_rope_aware_k.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+from turboquant_pro.model_compress import (  # noqa: E402
+    ModelCompressor,
+    quantize_weight_rows,
+    rope_protected_rows,
+)
+
+HIDDEN, N_HEADS, KV_HEADS, HEAD_DIM = 32, 4, 2, 8
+HALF = HEAD_DIM // 2
+THETA = 1e4
+
+
+class _Cfg:
+    hidden_size = HIDDEN
+    num_attention_heads = N_HEADS
+    rope_theta = THETA
+
+
+class _Rotary(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        inv = THETA ** (-torch.arange(HALF, dtype=torch.float32) / HALF)
+        self.register_buffer("inv_freq", inv)
+
+
+class _Attn(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.q_proj = nn.Linear(HIDDEN, N_HEADS * HEAD_DIM, bias=False)
+        self.k_proj = nn.Linear(HIDDEN, KV_HEADS * HEAD_DIM, bias=False)  # GQA
+        self.v_proj = nn.Linear(HIDDEN, KV_HEADS * HEAD_DIM, bias=False)
+        self.o_proj = nn.Linear(N_HEADS * HEAD_DIM, HIDDEN, bias=False)
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.self_attn = _Attn()
+        self.up_proj = nn.Linear(HIDDEN, 4 * HIDDEN, bias=False)
+        self.down_proj = nn.Linear(4 * HIDDEN, HIDDEN, bias=False)
+
+
+class _Model(nn.Module):
+    config = _Cfg()
+
+    def __init__(self, with_rotary: bool = True) -> None:
+        super().__init__()
+        torch.manual_seed(0)
+        self.layers = nn.ModuleList([_Block(), _Block()])
+        if with_rotary:
+            self.rotary = _Rotary()
+
+
+def _inv_freq() -> np.ndarray:
+    return THETA ** (-np.arange(HALF, dtype=np.float64) / HALF)
+
+
+class TestProtectedRowMask:
+    def test_fraction_and_longest_wavelength(self) -> None:
+        """protect_frac of frequency indices, the longest-wavelength ones."""
+        mask = rope_protected_rows(
+            KV_HEADS * HEAD_DIM, HEAD_DIM, _inv_freq(), protect_frac=0.25
+        )
+        # 25% of HALF=4 freqs -> 1 protected frequency; it pairs channels
+        # f and f+HALF in every head -> 2 rows per head x KV_HEADS heads
+        assert mask.sum() == 2 * KV_HEADS
+        # longest wavelength = highest frequency index (smallest inv_freq)
+        j = np.arange(KV_HEADS * HEAD_DIM)
+        f = (j % HEAD_DIM) % HALF
+        assert set(f[mask]) == {HALF - 1}
+
+    def test_rows_pair_across_rotate_half(self) -> None:
+        """Channels c and c+half share a frequency -> both protected."""
+        mask = rope_protected_rows(HEAD_DIM, HEAD_DIM, _inv_freq(), 0.25)
+        assert bool(mask[HALF - 1]) and bool(mask[HEAD_DIM - 1])
+
+    def test_bad_inv_freq_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="head_dim/2"):
+            rope_protected_rows(HEAD_DIM, HEAD_DIM, np.ones(3), 0.25)
+
+
+class TestQuantizeWeights:
+    def test_protected_rows_kept_exact(self) -> None:
+        model = _Model()
+        orig = {
+            n: m.weight.detach().clone()
+            for n, m in model.named_modules()
+            if isinstance(m, nn.Linear)
+        }
+        q = ModelCompressor(model).quantize_weights(bits=3, k_protect_frac=0.25)
+        mask = rope_protected_rows(KV_HEADS * HEAD_DIM, HEAD_DIM, _inv_freq(), 0.25)
+        for name, mod in q.named_modules():
+            if not isinstance(mod, nn.Linear):
+                continue
+            W0, W1 = orig[name], mod.weight.detach()
+            if "k_proj" in name:
+                assert torch.equal(W1[mask], W0[mask]), "protected rows changed"
+                assert not torch.allclose(
+                    W1[~mask], W0[~mask]
+                ), "unprotected K rows were not quantized"
+            else:
+                assert not torch.allclose(W1, W0), f"{name} not quantized"
+                expect = quantize_weight_rows(W0.float(), 3).to(W0.dtype)
+                assert torch.allclose(W1, expect)
+
+    def test_protect_bits_mixed_precision(self) -> None:
+        model = _Model()
+        k0 = model.layers[0].self_attn.k_proj.weight.detach().clone()
+        q = ModelCompressor(model).quantize_weights(
+            bits=3, k_protect_frac=0.25, k_protect_bits=8
+        )
+        mask = torch.from_numpy(
+            rope_protected_rows(KV_HEADS * HEAD_DIM, HEAD_DIM, _inv_freq(), 0.25)
+        )
+        k1 = q.layers[0].self_attn.k_proj.weight.detach()
+        expect8 = quantize_weight_rows(k0.float(), 8).to(k0.dtype)
+        expect3 = quantize_weight_rows(k0.float(), 3).to(k0.dtype)
+        assert torch.allclose(k1[mask], expect8[mask])
+        assert torch.allclose(k1[~mask], expect3[~mask])
+
+    def test_disabled_quantizes_all_k_rows(self) -> None:
+        model = _Model()
+        k0 = model.layers[0].self_attn.k_proj.weight.detach().clone()
+        q = ModelCompressor(model).quantize_weights(bits=3, rope_aware_k=False)
+        k1 = q.layers[0].self_attn.k_proj.weight.detach()
+        assert torch.allclose(k1, quantize_weight_rows(k0.float(), 3).to(k0.dtype))
+
+    def test_inv_freq_buffer_preferred_over_config(self) -> None:
+        """A (scaled) inv_freq buffer must win over config.rope_theta."""
+        model = _Model()
+        # scramble the buffer so the longest wavelength sits at index 0
+        model.rotary.inv_freq = torch.flip(model.rotary.inv_freq, [0])
+        q = ModelCompressor(model).quantize_weights(bits=3, k_protect_frac=0.25)
+        k0 = _Model().layers[0].self_attn.k_proj.weight  # same seed
+        k1 = q.layers[0].self_attn.k_proj.weight
+        j = np.arange(KV_HEADS * HEAD_DIM)
+        f = (j % HEAD_DIM) % HALF
+        assert torch.equal(k1[f == 0], k0[f == 0])  # index 0 now protected
+
+    def test_config_theta_fallback(self) -> None:
+        model = _Model(with_rotary=False)  # no inv_freq buffer anywhere
+        q = ModelCompressor(model).quantize_weights(bits=3, k_protect_frac=0.25)
+        mask = rope_protected_rows(KV_HEADS * HEAD_DIM, HEAD_DIM, _inv_freq(), 0.25)
+        k0 = _Model(with_rotary=False).layers[0].self_attn.k_proj.weight
+        k1 = q.layers[0].self_attn.k_proj.weight
+        assert torch.equal(k1[mask], k0[mask])
+
+    def test_no_rope_geometry_warns_and_degrades(self, caplog) -> None:
+        model = _Model(with_rotary=False)
+        model.config = type(
+            "C", (), {"hidden_size": HIDDEN, "num_attention_heads": N_HEADS}
+        )()
+        with caplog.at_level("WARNING"):
+            q = ModelCompressor(model).quantize_weights(bits=3)
+        assert "no rotary geometry" in caplog.text
+        k0 = _Model(with_rotary=False).layers[0].self_attn.k_proj.weight
+        k1 = q.layers[0].self_attn.k_proj.weight
+        assert torch.allclose(k1, quantize_weight_rows(k0.float(), 3).to(k0.dtype))
+
+    def test_not_inplace_by_default(self) -> None:
+        model = _Model()
+        k0 = model.layers[0].self_attn.k_proj.weight.detach().clone()
+        ModelCompressor(model).quantize_weights(bits=3)
+        assert torch.equal(model.layers[0].self_attn.k_proj.weight, k0)

--- a/turboquant_pro/model_compress.py
+++ b/turboquant_pro/model_compress.py
@@ -139,6 +139,79 @@ def _analyze_matrix(
     )
 
 
+# ─── RoPE-aware weight quantization (the measured K-row mechanism) ────
+#
+# Measured in docs/notes/projection_sensitivity_deconfounded.md section 2.3:
+# at low bit-widths the damaging rows of W^K are the LONG-WAVELENGTH (DC)
+# RoPE rows -- on Llama-3.2-3B at 3-bit, sparing the single longest-wavelength
+# octile (12.5% of K rows, ~0.4% of attention weights) recovers 87% of the
+# functional damage (out_kl 0.741 -> 0.099); the coupling replicates at 25x
+# smaller amplitude on Mistral-7B. Per-row weight error is blind to it
+# (Spearman vs wavelength +0.12): the fragile rows are not quantized worse,
+# they feed softmax's absolute reference. Hence: protect those rows, not
+# "more bits for K everywhere."
+
+
+def quantize_weight_rows(W, bits: int):
+    """Uniform symmetric per-row (output-channel) absmax quantize->dequantize
+    (torch). The same matched control as the section-2.2 experiments."""
+    qmax = 2 ** (bits - 1) - 1
+    amax = W.abs().amax(dim=1, keepdim=True).clamp_min(1e-8)
+    scale = amax / qmax
+    return torch.clamp(torch.round(W / scale), -qmax - 1, qmax) * scale
+
+
+def rope_protected_rows(
+    out_features: int,
+    head_dim: int,
+    inv_freq,
+    protect_frac: float = 0.125,
+) -> np.ndarray:
+    """Boolean mask over W^K's output rows: True = long-wavelength (protect).
+
+    Rows map to key channels; channel ``c`` pairs with rotary frequency index
+    ``(c mod head_dim) mod (head_dim/2)``. The ``protect_frac`` fraction of
+    frequency indices with the longest wavelengths (smallest ``inv_freq``) is
+    protected -- default 0.125, the measured 87%-recovery octile.
+    """
+    half = head_dim // 2
+    inv = np.asarray(inv_freq, dtype=np.float64).reshape(-1)
+    if inv.shape[0] != half:
+        raise ValueError(
+            f"inv_freq has {inv.shape[0]} entries, expected head_dim/2 = {half}"
+        )
+    n_protect = max(1, int(round(protect_frac * half)))
+    protected_f = np.argsort(inv)[:n_protect]  # smallest inv_freq = longest lambda
+    f = (np.arange(out_features) % head_dim) % half
+    return np.isin(f, protected_f)
+
+
+def _model_inv_freq(model, head_dim: int):
+    """The model's own rotary ``inv_freq`` buffer (rope_scaling included), or a
+    config-derived fallback, or ``None`` when RoPE geometry is undeterminable."""
+    half = head_dim // 2
+    for mod in model.modules():
+        buf = getattr(mod, "inv_freq", None)
+        if buf is not None and getattr(buf, "shape", (0,))[-1] == half:
+            return buf.detach().float().cpu().numpy()
+    cfg = getattr(model, "config", None)
+    theta = None
+    if cfg is not None:
+        theta = getattr(cfg, "rope_theta", None)
+        if theta is None:
+            # transformers 5.x can nest it in a rope-parameters dict
+            rp = getattr(cfg, "rope_parameters", None) or {}
+            theta = rp.get("rope_theta") if isinstance(rp, dict) else None
+    if theta is None:
+        return None
+    logger.warning(
+        "no inv_freq buffer found; deriving from rope_theta=%s "
+        "(rope_scaling, if any, is NOT reflected)",
+        theta,
+    )
+    return float(theta) ** (-np.arange(half, dtype=np.float64) / half)
+
+
 # ─── Main compressor ─────────────────────────────────────────
 
 
@@ -495,6 +568,124 @@ class ModelCompressor:
             compressed_count,
             target_ratio,
             total_removed,
+        )
+        return self._model
+
+    # ── RoPE-aware weight quantization ─────────────────────────
+
+    def quantize_weights(
+        self,
+        bits: int = 4,
+        *,
+        rope_aware_k: bool = True,
+        k_protect_frac: float = 0.125,
+        k_protect_bits: int | None = None,
+        head_dim: int | None = None,
+        inplace: bool = False,
+    ):
+        """Fake-quantize FFN + attention weights per output channel, protecting
+        the long-wavelength RoPE rows of ``W^K``.
+
+        Every ``nn.Linear`` found among the FFN/attention targets is
+        quantize->dequantized with uniform symmetric per-row absmax at
+        ``bits``. With ``rope_aware_k=True`` (default), each ``k_proj``'s rows
+        whose rotary frequency falls in the ``k_protect_frac`` longest-
+        wavelength fraction are **kept in full precision** (or quantized at
+        ``k_protect_bits`` if given, e.g. 8) — the surgical fix measured in
+        ``docs/notes/projection_sensitivity_deconfounded.md`` §2.3: at 3-bit
+        on Llama-3.2-3B, protecting 12.5% of K rows (~0.4% of attention
+        weights) recovers 87% of the functional damage.
+
+        Rotary geometry is read from the model's own ``inv_freq`` buffer
+        (rope_scaling included), falling back to ``config.rope_theta``; if
+        neither exists, K protection is skipped with a warning (the model is
+        presumably not rotary). ``head_dim`` overrides config detection.
+
+        Args:
+            bits: Bit-width for the uniform per-output-channel quantizer.
+            rope_aware_k: Protect long-wavelength ``k_proj`` rows.
+            k_protect_frac: Fraction of rotary frequencies to protect
+                (default 0.125 — the measured 87%-recovery octile).
+            k_protect_bits: If set, protected rows are quantized at this
+                width instead of kept full-precision.
+            head_dim: Attention head dimension; default from ``model.config``.
+            inplace: If True, modify the model in place.
+
+        Returns:
+            The (fake-)quantized model.
+        """
+        if not inplace:
+            import copy
+
+            model = copy.deepcopy(self._model)
+            compressor = ModelCompressor(model)
+            return compressor.quantize_weights(
+                bits=bits,
+                rope_aware_k=rope_aware_k,
+                k_protect_frac=k_protect_frac,
+                k_protect_bits=k_protect_bits,
+                head_dim=head_dim,
+                inplace=True,
+            )
+
+        cfg = getattr(self._model, "config", None)
+        if head_dim is None and cfg is not None:
+            head_dim = getattr(cfg, "head_dim", None)
+            if head_dim is None:
+                hidden = getattr(cfg, "hidden_size", None)
+                n_heads = getattr(cfg, "num_attention_heads", None)
+                if hidden and n_heads:
+                    head_dim = hidden // n_heads
+
+        k_mask_cache: dict[int, np.ndarray] = {}
+        inv_freq = None
+        if rope_aware_k:
+            if head_dim is None:
+                logger.warning(
+                    "rope_aware_k: cannot determine head_dim — K rows will "
+                    "not be protected (pass head_dim= explicitly)"
+                )
+                rope_aware_k = False
+            else:
+                inv_freq = _model_inv_freq(self._model, head_dim)
+                if inv_freq is None:
+                    logger.warning(
+                        "rope_aware_k: no rotary geometry found (no inv_freq "
+                        "buffer, no config.rope_theta) — K rows will not be "
+                        "protected"
+                    )
+                    rope_aware_k = False
+
+        n_quantized = n_protected_rows = n_k_rows = 0
+        for name, module in self._ffn_layers + self._attn_layers:
+            W = module.weight.data
+            Wq = quantize_weight_rows(W.float(), bits)
+            if rope_aware_k and "k_proj" in name:
+                out_f = W.shape[0]
+                if out_f not in k_mask_cache:
+                    k_mask_cache[out_f] = rope_protected_rows(
+                        out_f, head_dim, inv_freq, k_protect_frac
+                    )
+                mask = torch.from_numpy(k_mask_cache[out_f]).to(W.device)
+                if k_protect_bits is not None:
+                    Wq[mask] = quantize_weight_rows(W.float(), k_protect_bits)[mask]
+                else:
+                    Wq[mask] = W.float()[mask]
+                n_protected_rows += int(mask.sum())
+                n_k_rows += out_f
+            module.weight.data = Wq.to(dtype=W.dtype)
+            n_quantized += 1
+
+        logger.info(
+            "quantize_weights: %d layers at %d-bit%s",
+            n_quantized,
+            bits,
+            (
+                f", protected {n_protected_rows}/{n_k_rows} k_proj rows "
+                f"({'fp' if k_protect_bits is None else f'{k_protect_bits}-bit'})"
+                if n_k_rows
+                else ""
+            ),
         )
         return self._model
 


### PR DESCRIPTION
## What

Wires the measured §2.3 mechanism (`docs/notes/projection_sensitivity_deconfounded.md`, 28db1ef) into the weight path — incident → instrument, weight-space edition.

**`ModelCompressor.quantize_weights(bits, rope_aware_k=True, k_protect_frac=0.125, k_protect_bits=None, ...)`** — the module's first quantization path (previously SVD/PCA truncation only): uniform symmetric per-output-channel absmax over FFN + attention Linears (the experiments' exact matched control). With `rope_aware_k=True` (default), each `k_proj`'s longest-wavelength rows are kept full-precision (or quantized at `k_protect_bits`, e.g. 8, for mixed precision).

**Evidence-backed default**: `k_protect_frac=0.125` is the measured 87%-recovery octile — on Llama-3.2-3B at 3-bit, protecting 12.5% of K rows (~0.4% of attention weights) recovers the anomaly from out_kl 0.741 → 0.099; the wavelength–damage coupling replicates at 25× smaller amplitude on Mistral-7B.

**Details that matter**: rotary geometry read from the model's own `inv_freq` buffer so rope-scaling is respected (exactly what made Llama-3.2 fragile), `rope_theta` config fallback with a scaling-not-reflected warning (handles the transformers-5.x nested rope-parameters dict), graceful warn-and-degrade on non-rotary models, rotate-half `c`/`c+half` pairing and GQA out-features handled in `rope_protected_rows`.

## Validation

- 10 new tests (`tests/test_rope_aware_k.py`): mask math, protected-rows-bit-exact, mixed precision vs both quantizers, buffer-beats-config precedence, fallbacks, inplace semantics.
- Full suite 581 passed; ruff + black clean. Purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)