### PR TITLE
Volta (sm_70) fused KV attention-on-codes decode kernels (K2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,5 @@ jobs:
         continue-on-error: true
 
       - name: Run tests
-        run: pytest tests/test_core.py tests/test_cache.py tests/test_pgvector.py tests/test_nats_codec.py tests/test_behavioral_agreement.py tests/test_operator_trace.py tests/test_operator_sensitivity.py -v
+        run: pytest tests/test_core.py tests/test_cache.py tests/test_pgvector.py tests/test_nats_codec.py tests/test_behavioral_agreement.py tests/test_operator_trace.py tests/test_operator_sensitivity.py tests/test_volta_k2.py -v
         # GPU tests (test_cuda.py) are skipped in CI -- no CUDA available

--- a/benchmarks/bench_k2_volta.py
+++ b/benchmarks/bench_k2_volta.py
@@ -1,0 +1,101 @@
+# TurboQuant Pro: benchmark for the Volta K2 fused key-score kernel.
+# Copyright (c) 2026 Andrew H. Bond. MIT License.
+"""Benchmark the K2 fused per-channel key-score decode on a Volta GV100.
+
+Compares the fused kernel (:func:`turboquant_pro.volta_kernels.k2_key_scores`)
+against two baselines that both touch an ``(H,S,D)`` fp32 intermediate:
+
+  * ``decompress+attend`` -- rebuild K then ``einsum(q, K)``
+  * ``einsum(codes)``     -- the current :mod:`kv_fused_pck` path,
+                            ``einsum(w, grid[codes])`` (materializes ``grid[codes]``)
+
+The kernel touches only the 1-byte codes. Run on an uncontended GV100 for
+meaningful numbers::
+
+    CUDA_VISIBLE_DEVICES=0 python benchmarks/bench_k2_volta.py
+
+Measured on a Quadro GV100 (uncontended): ~12--20x over decompress+attend and
+~5x over einsum(codes) at ``S in {4k, 8k}``, exact to fp32 rounding.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from turboquant_pro.per_channel_kv import _NF4
+from turboquant_pro.volta_kernels import k2_key_scores
+
+try:
+    import cupy as cp
+except ImportError:  # pragma: no cover
+    cp = None
+
+
+def _bench_case(H, S, D, reps=100):
+    rng = np.random.default_rng(0)
+    codes = rng.integers(0, 16, size=(H, S, D), dtype=np.uint8)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    weight = (0.5 + rng.random((H, D))).astype(np.float32)
+    mu = (0.1 * rng.standard_normal((H, D))).astype(np.float32)
+    w = (q * weight).astype(np.float32)
+    bias = (q * mu).sum(1).astype(np.float32)
+
+    ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
+
+    d_codes, d_w, d_bias = cp.asarray(codes), cp.asarray(w), cp.asarray(bias)
+    d_grid, d_q = cp.asarray(_NF4), cp.asarray(q)
+    d_weight, d_mu = cp.asarray(weight), cp.asarray(mu)
+
+    err = float(
+        cp.abs(k2_key_scores(d_codes, d_w, d_bias, d_grid) - cp.asarray(ref)).max()
+    )
+    print(f"[correct] H={H} S={S} D={D}  kernel max abs err = {err:.2e}")
+
+    def kernel():
+        k2_key_scores(d_codes, d_w, d_bias, d_grid)
+
+    def decompress_attend():
+        K = d_mu[:, None, :] + d_weight[:, None, :] * d_grid[d_codes]
+        cp.einsum("hd,hsd->hs", d_q, K)
+
+    def einsum_codes():
+        cp.einsum(
+            "hd,hsd->hs", d_w, d_grid[d_codes]
+        )  # noqa: F841 (+bias omitted; timing)
+
+    results = {}
+    for name, fn in [
+        ("kernel", kernel),
+        ("decompress+attend", decompress_attend),
+        ("einsum(codes)", einsum_codes),
+    ]:
+        fn()
+        cp.cuda.Stream.null.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            fn()
+        cp.cuda.Stream.null.synchronize()
+        ms = (time.perf_counter() - t0) / reps * 1e3
+        results[name] = ms
+        gbps = H * S * D / (ms * 1e-3) / 1e9
+        print(f"  {name:20s} {ms:8.3f} ms   (codes {gbps:6.1f} GB/s)")
+    base = results["decompress+attend"]
+    print(
+        f"  -> kernel speedup: {base / results['kernel']:.1f}x vs decompress+attend, "
+        f"{results['einsum(codes)'] / results['kernel']:.1f}x vs einsum(codes)"
+    )
+
+
+def main():
+    if cp is None:
+        raise SystemExit("this benchmark needs CuPy on a CUDA device")
+    print("gpu", cp.cuda.runtime.getDeviceProperties(0)["name"].decode())
+    for H, S, D in [(8, 4096, 128), (32, 4096, 128), (32, 8192, 128)]:
+        _bench_case(H, S, D)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/notes/volta_k2_kv_decode.md
+++ b/docs/notes/volta_k2_kv_decode.md
@@ -89,14 +89,37 @@ GV100). The scalar kernel remains the odd-`D` fallback. K2 is now closer to
 bandwidth-bound, so packing (P1) should begin to pay as a speedup too — an open
 follow-up (the packed LUT kernel has not yet had the vec/ns treatment).
 
+## P3 finding — vec/ns on the packed kernel: ~1.5× over baseline packed, but still
+## not a speedup over unpacked
+
+Applied the same vec+ns4 recipe to the packed path: each lane reads a `uint16`
+(2 bytes = 4 codes) per row, the format-decode LUT turns each byte into its two
+codes, and NS=4 `s` rows stay in flight. Uncontended GV100 (exact 5.7e-6):
+
+| shape (H,S,D) | unpacked (tuned) | packed base (P1) | packed vec+ns4 |
+|---|---|---|---|
+| 32, 4096, 128  | 0.040 ms | 0.063 ms | 0.046 ms (0.86× unpacked) |
+| 32, 8192, 128  | 0.073 ms | 0.121 ms | 0.087 ms (0.84×) |
+| 32, 16384, 128 | 0.159 ms | 0.256 ms | 0.179 ms (0.89×) |
+| 8, 8192, 128   | 0.023 ms | 0.030 ms | 0.020 ms (**1.15×**) |
+
+**~1.5× faster than the P1 packed baseline**, near-parity with the tuned unpacked
+(even faster at small H). But packing still does **not** beat unpacked decode: a
+D=128 packed row is only 64B — half a 128B transaction — so the packed kernel
+tops out at ~24% of peak and can't go bandwidth-bound the way unpacked (uint32,
+full line) does. Confirms the P1 verdict *after* tuning: packing is a **storage**
+win (half the KV cache) at ~parity decode. A `gridLUT` variant (byte → grid-value
+pairs, killing the code→grid indirection) was slightly faster at small S but its
+2 KB shared table **regressed at large S** (occupancy), so `vec+ns4` (small shared,
+consistent) shipped instead. Both dead ends recorded honestly.
+
 ## Status / next
 
 - [x] v1 kernel (unpacked uint8 codes), exactness tests, benchmark.
-- [x] **Packed 4-bit codes** — LUT kernel, exact, parity decode at half storage;
-      general per-bit kernel for 2/3-bit.
 - [x] **Occupancy tuning** — vec4+ns4, ~34% → ~60% of peak (1.6–1.9×); shipped.
-- [ ] **Apply vec/ns to the packed LUT kernel** — now that decode is nearer
-      bandwidth-bound, packing's half-traffic should convert to a speedup.
+- [x] **Packed 4-bit codes + vec/ns** — uint16+LUT+ns4, ~1.5× over naive packed,
+      near-parity with unpacked at half storage; general per-bit kernel for 2/3-bit.
+      Packing is a storage win, not a decode speedup (64B-row transaction limit).
 - [ ] **Outlier CSR deltas** in-kernel (or a fused second pass) — currently the
       caller adds `build_outlier_csr` contributions; fold them so the sparse path
       stays on-GPU.

--- a/docs/notes/volta_k2_kv_decode.md
+++ b/docs/notes/volta_k2_kv_decode.md
@@ -64,19 +64,43 @@ codes) with contiguous channel-pair assignment, which reaches **parity** (~0.9×
 at **half the KV-cache storage**. So packing buys memory, not latency; the speedup
 lever is occupancy tuning (below), after which packing would also help.
 
+## P2 finding — occupancy tuning: ~34% → ~60% of peak (1.6–1.9×)
+
+The scalar one-warp-per-`(h,s)` kernel did too little work per warp (four 32B
+byte-loads + a shuffle-reduce) and sat at ~34% of HBM2 peak. Two changes, measured
+independently on an uncontended GV100 (unpacked, exact 5.7e-6):
+
+| shape (H,S,D) | scalar | vec4 | vec4+ns4 | vec4+ns4 vs scalar |
+|---|---|---|---|---|
+| 32, 4096, 128  | 0.0552 ms (35%) | 0.0537 (36%) | 0.0347 ms (**56%**) | 1.59× |
+| 32, 8192, 128  | 0.1139 ms (34%) | 0.1058 (37%) | 0.0644 ms (**60%**) | 1.77× |
+| 32, 16384, 128 | 0.2340 ms (33%) | 0.2831 (27%) | 0.1229 ms (**63%**) | 1.90× |
+
+- **vec4** — each lane reads a `uint32` (4 codes) → one coalesced 128B transaction
+  per warp instead of four 32B ones. *Alone it barely helps* (even regresses at
+  large S): fewer instructions but the warp is still latency-stalled.
+- **vec4+ns4** — each warp also keeps **NS=4 independent `s` rows** in flight, so
+  four loads overlap before any reduction. This memory-level parallelism is the
+  real lever → ~55–63% of peak. `ns8` gave nothing over `ns4` and costs registers.
+
+Shipped as `_KERNEL_SRC_VEC4NS` (default when `D % 4 == 0`; bounds-checked so S
+need not be a multiple of 4 — validated at S=1023/1021/777 and D=64/96 on the
+GV100). The scalar kernel remains the odd-`D` fallback. K2 is now closer to
+bandwidth-bound, so packing (P1) should begin to pay as a speedup too — an open
+follow-up (the packed LUT kernel has not yet had the vec/ns treatment).
+
 ## Status / next
 
 - [x] v1 kernel (unpacked uint8 codes), exactness tests, benchmark.
-- [x] **Packed 4-bit codes** — LUT kernel, exact, parity decode at half storage
-      (see finding above); general per-bit kernel for 2/3-bit.
-- [ ] **Occupancy tuning** (now the priority) — more `(h,s)` per warp / ILP /
-      vectorized loads to become bandwidth-bound; only then does packing speed up.
+- [x] **Packed 4-bit codes** — LUT kernel, exact, parity decode at half storage;
+      general per-bit kernel for 2/3-bit.
+- [x] **Occupancy tuning** — vec4+ns4, ~34% → ~60% of peak (1.6–1.9×); shipped.
+- [ ] **Apply vec/ns to the packed LUT kernel** — now that decode is nearer
+      bandwidth-bound, packing's half-traffic should convert to a speedup.
 - [ ] **Outlier CSR deltas** in-kernel (or a fused second pass) — currently the
       caller adds `build_outlier_csr` contributions; fold them so the sparse path
       stays on-GPU.
 - [ ] **Values leg** — merge PolarQuant value partials (the `pck_cold_partials`
       online-softmax) so the whole decode step is one fused path.
-- [ ] **Tuning** — LUT shared-bank layout, block granularity, and `S`-tiling to
-      push past ~31% of HBM2 peak.
 - [ ] **Integration** — dispatch `k2_key_scores` from `kv_fused_pck` when CuPy +
       an `sm_70` device are present, else keep the einsum reference.

--- a/docs/notes/volta_k2_kv_decode.md
+++ b/docs/notes/volta_k2_kv_decode.md
@@ -150,6 +150,8 @@ in cupy (neither materializes a large tensor).
 - [x] **Values leg** (`value_accum`) — 12–16× over cupy einsum; fused.
 - [x] **Outlier CSR deltas** (`apply_outlier_csr`) — on-GPU sparse key correction.
 - [x] **Whole cold-block decode** validated against `pck_cold_partials`.
-- [ ] **Integration** — dispatch these from `kv_fused_pck`/`kv_kernel` when CuPy +
-      an `sm_70` device are present, else keep the einsum reference. (Wiring only;
-      the kernels and the end-to-end equivalence are done.)
+- [x] **Integration** — `kv_fused_pck.pck_key_scores` / `pck_cold_partials` dispatch
+      to the K2 kernels when `xp` is CuPy (else the einsum reference). A test runs the
+      dispatched path (keys with outliers) against the NumPy reference on the GV100.
+- [ ] Future: `kv_kernel.fused_decode_cuda` hook; apply vec/ns to the packed kernel's
+      remaining headroom; K1 (W4A16 GEMM) is the separate tensor-core track.

--- a/docs/notes/volta_k2_kv_decode.md
+++ b/docs/notes/volta_k2_kv_decode.md
@@ -1,0 +1,59 @@
+# Volta K2 — fused KV attention-on-codes decode (P0)
+
+Part of the Volta-kernel track (extend the existing CuPy/NVRTC kernel layer for
+`sm_70`; do not fork CUDA). K2 is the memory-bandwidth play — fuse the
+per-channel-KV dequant into the score so fp16/fp32 K is never materialized. It
+does **not** use tensor cores (`wmma`/`HMMA.884` is K1's concern), so it is the
+low-risk first kernel.
+
+## What it computes
+
+Per-channel asym-NF4 keys enter attention only through `q·k`, so:
+
+    score[h,s] = bias[h] + sum_d w[h,d] * grid[code[h,s,d]]
+      w    = q * per-channel weight   (H,D)
+      bias = sum_d q * per-channel mu (H,)   -- zero-point folded
+      grid = NF4 / uniform codebook   (L,)
+
+`kv_fused_pck.pck_key_scores` expresses this as `einsum(w, grid[codes])`, which is
+correct but materializes `grid[codes]` — an `(H,S,D)` fp32 tensor, the same
+bandwidth as decompressing. `volta_kernels.k2_key_scores` reads the 1-byte codes
+directly and does the LUT-dequant + dot in registers.
+
+## Kernel (v1)
+
+One warp per `(h,s)`: 32 lanes stride the head dim `D` (coalesced byte reads of
+`codes`), the NF4 grid lives in shared memory, a warp shuffle reduces the partial
+dot, lane 0 writes `acc + bias[h]`. Compiled lazily via CuPy NVRTC (arch auto =
+`compute_70` on a GV100). No `cp.async`/`ldmatrix`/tensor cores — none needed for
+a memory-bound GEMV.
+
+## Measured (Quadro GV100, uncontended, fp32 codes intermediate for baselines)
+
+| shape (H,S,D) | kernel | decompress+attend | einsum(codes) | speedup |
+|---|---|---|---|---|
+| 8, 4096, 128  | 0.016 ms | 0.397 ms | 0.333 ms | 24.8× / 20.8× |
+| 32, 4096, 128 | 0.056 ms | 1.094 ms | 0.316 ms | 19.5× / 5.6× |
+| 32, 8192, 128 | 0.125 ms | 1.538 ms | 0.622 ms | 12.3× / 5.0× |
+
+Exact vs the NumPy reference and vs `pck_key_scores` (asym-NF4, dense) to fp32
+rounding (~5e-6). Kernel sustains ~270–300 GB/s of codes traffic, ≈31% of the
+GV100's ~870 GB/s HBM2 peak — so there is tuning headroom.
+
+The K1 kill-criterion bar (≥1.3× over dequant+cuBLAS) does not apply to K2, but
+for reference K2 clears it by 10×+.
+
+## Status / next (P1)
+
+- [x] v1 kernel (unpacked uint8 codes), exactness tests, benchmark.
+- [ ] **Packed 4-bit codes** — read 0.5 byte/code (2× less traffic again); the
+      container already supports `packed=True`.
+- [ ] **Outlier CSR deltas** in-kernel (or a fused second pass) — currently the
+      caller adds `build_outlier_csr` contributions; fold them so the sparse path
+      stays on-GPU.
+- [ ] **Values leg** — merge PolarQuant value partials (the `pck_cold_partials`
+      online-softmax) so the whole decode step is one fused path.
+- [ ] **Tuning** — LUT shared-bank layout, block granularity, and `S`-tiling to
+      push past ~31% of HBM2 peak.
+- [ ] **Integration** — dispatch `k2_key_scores` from `kv_fused_pck` when CuPy +
+      an `sm_70` device are present, else keep the einsum reference.

--- a/docs/notes/volta_k2_kv_decode.md
+++ b/docs/notes/volta_k2_kv_decode.md
@@ -113,6 +113,33 @@ pairs, killing the code→grid indirection) was slightly faster at small S but i
 2 KB shared table **regressed at large S** (occupancy), so `vec+ns4` (small shared,
 consistent) shipped instead. Both dead ends recorded honestly.
 
+## P4 — values leg + outlier CSR: the whole cold-block decode fused
+
+The decode has three code-reading terms; P0–P3 did the keys, P4 adds the other two
+so the entire `pck_cold_partials` runs on-GPU with no `(H,S,D)` fp32 intermediate.
+
+**Values leg** (`value_accum`) — the transpose of the key score:
+`acc_code[h,d] = sum_s (e·norm_v)[h,s] · cent[vcode[h,s,d]]`, reduced over S with a
+scalar PolarQuant codebook. Block per `(h, s-chunk)`, one thread per `d` so the
+`vcodes` reads coalesce, S split across blocks with `atomicAdd` (SCH=128 best).
+Uncontended GV100 vs the cupy `einsum(cent[vcodes])`:
+
+| shape (H,S,D) | value kernel | einsum | speedup |
+|---|---|---|---|
+| 32, 4096, 128 | 0.066 ms (30% peak) | 0.77 ms | **11.8×** |
+| 32, 8192, 128 | 0.093 ms (42% peak) | 1.46 ms | **15.8×** |
+
+**Outlier CSR** (`apply_outlier_csr`) — dense-and-sparse keeps the top-magnitude
+key entries in fp16; `build_outlier_csr` turns them into token-major score deltas.
+One thread per `(h,s)` row adds `sum_k q[h,cols[k]]·deltas[k]` on-GPU, so the sparse
+correction no longer round-trips to a NumPy scatter.
+
+**End-to-end**: a test composes `k2_key_scores` → `apply_outlier_csr` → softmax
+(cupy, cheap on `(H,S)`) → `value_accum` → `@ pi` and matches `pck_cold_partials`
+`(m, lsum, acc)` to fp32 tolerance on the GV100. The two heavy code-reading einsums
+are now fused kernels; only the softmax and the tiny `(H,D)@(D,D)` unrotation stay
+in cupy (neither materializes a large tensor).
+
 ## Status / next
 
 - [x] v1 kernel (unpacked uint8 codes), exactness tests, benchmark.
@@ -120,10 +147,9 @@ consistent) shipped instead. Both dead ends recorded honestly.
 - [x] **Packed 4-bit codes + vec/ns** — uint16+LUT+ns4, ~1.5× over naive packed,
       near-parity with unpacked at half storage; general per-bit kernel for 2/3-bit.
       Packing is a storage win, not a decode speedup (64B-row transaction limit).
-- [ ] **Outlier CSR deltas** in-kernel (or a fused second pass) — currently the
-      caller adds `build_outlier_csr` contributions; fold them so the sparse path
-      stays on-GPU.
-- [ ] **Values leg** — merge PolarQuant value partials (the `pck_cold_partials`
-      online-softmax) so the whole decode step is one fused path.
-- [ ] **Integration** — dispatch `k2_key_scores` from `kv_fused_pck` when CuPy +
-      an `sm_70` device are present, else keep the einsum reference.
+- [x] **Values leg** (`value_accum`) — 12–16× over cupy einsum; fused.
+- [x] **Outlier CSR deltas** (`apply_outlier_csr`) — on-GPU sparse key correction.
+- [x] **Whole cold-block decode** validated against `pck_cold_partials`.
+- [ ] **Integration** — dispatch these from `kv_fused_pck`/`kv_kernel` when CuPy +
+      an `sm_70` device are present, else keep the einsum reference. (Wiring only;
+      the kernels and the end-to-end equivalence are done.)

--- a/docs/notes/volta_k2_kv_decode.md
+++ b/docs/notes/volta_k2_kv_decode.md
@@ -43,11 +43,34 @@ GV100's ~870 GB/s HBM2 peak — so there is tuning headroom.
 The K1 kill-criterion bar (≥1.3× over dequant+cuBLAS) does not apply to K2, but
 for reference K2 clears it by 10×+.
 
-## Status / next (P1)
+## P1 finding — packed codes are a storage win, not a speedup
+
+`k2_key_scores_packed` reads the container's `packed=True` bytes (the bit-reversed
+`_pack_indices` layout). Correct to fp32 (5.7e-6). Measured on an uncontended
+GV100 (bits=4):
+
+| shape (H,S,D) | unpacked | packed | vs unpacked | vs decompress+attend |
+|---|---|---|---|---|
+| 32, 4096, 128 | 0.071 ms | 0.079 ms | 0.89× | 11.0× |
+| 32, 8192, 128 | 0.125 ms | 0.139 ms | 0.90× | 11.4× |
+| 8, 8192, 128  | 0.030 ms | 0.031 ms | 0.97× | 13.1× |
+
+**Packing does not speed decode** — K2 is latency/occupancy-bound (~31% of HBM2
+peak), so reading half the bytes doesn't cut time. Two dead ends were measured and
+discarded honestly: naive per-bit reconstruction was **3× slower** than unpacked
+(4 byte-loads + bit ops per code); a single-load-per-code variant was still ~3×.
+The shipped bits=4 kernel uses a 256-entry format-decode LUT (byte → its two
+codes) with contiguous channel-pair assignment, which reaches **parity** (~0.9×)
+at **half the KV-cache storage**. So packing buys memory, not latency; the speedup
+lever is occupancy tuning (below), after which packing would also help.
+
+## Status / next
 
 - [x] v1 kernel (unpacked uint8 codes), exactness tests, benchmark.
-- [ ] **Packed 4-bit codes** — read 0.5 byte/code (2× less traffic again); the
-      container already supports `packed=True`.
+- [x] **Packed 4-bit codes** — LUT kernel, exact, parity decode at half storage
+      (see finding above); general per-bit kernel for 2/3-bit.
+- [ ] **Occupancy tuning** (now the priority) — more `(h,s)` per warp / ILP /
+      vectorized loads to become bandwidth-bound; only then does packing speed up.
 - [ ] **Outlier CSR deltas** in-kernel (or a fused second pass) — currently the
       caller adds `build_outlier_csr` contributions; fold them so the sparse path
       stays on-GPU.

--- a/tests/test_volta_k2.py
+++ b/tests/test_volta_k2.py
@@ -1,0 +1,71 @@
+# TurboQuant Pro: tests for the Volta K2 fused key-score kernel.
+# Copyright (c) 2026 Andrew H. Bond. MIT License.
+"""Exactness tests for :mod:`turboquant_pro.volta_kernels` (K2).
+
+The CPU-fallback and format-integration tests run everywhere (NumPy only). The
+CuPy kernel test skips when CuPy / a CUDA device is unavailable, mirroring the
+torch-optional tests.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from turboquant_pro.kv_fused_pck import _grid_params, pck_key_scores
+from turboquant_pro.per_channel_kv import _NF4, PerChannelKV
+from turboquant_pro.volta_kernels import k2_key_scores
+
+
+def _synth(H=8, S=257, D=128, seed=0):
+    rng = np.random.default_rng(seed)
+    codes = rng.integers(0, 16, size=(H, S, D), dtype=np.uint8)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    weight = (0.5 + rng.random((H, D))).astype(np.float32)
+    mu = (0.1 * rng.standard_normal((H, D))).astype(np.float32)
+    w = (q * weight).astype(np.float32)
+    bias = (q * mu).sum(1).astype(np.float32)
+    return codes, w, bias
+
+
+def test_cpu_fallback_matches_reference():
+    codes, w, bias = _synth()
+    got = k2_key_scores(codes, w, bias, _NF4)
+    ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
+    assert got.shape == (codes.shape[0], codes.shape[1])
+    assert np.allclose(got, ref, atol=1e-5)
+
+
+def test_matches_pck_reference_dense():
+    """The kernel primitive reproduces the real per-channel-KV score path
+    (asym-NF4, no outliers) computed by ``kv_fused_pck.pck_key_scores``."""
+    H, S, D = 6, 129, 128
+    rng = np.random.default_rng(1)
+    x = (0.3 * rng.standard_normal((1, H, S, D))).astype(np.float32)
+    x[:, :, :, ::7] += 2.0  # a DC offset the asym zero-point must absorb
+    q_kv = PerChannelKV(head_dim=D, n_heads=H, bits=4, nf4_asym=True)
+    c = q_kv.compress(x)  # outlier_frac=0 -> dense only
+
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    mu, weight, grid = _grid_params(q_kv, c)
+    w = (q * weight).astype(np.float32)
+    bias = (q * mu).sum(1).astype(np.float32)
+    codes = c.indices[0]  # (H,S,D) uint8 (unpacked)
+
+    got = k2_key_scores(codes, w, bias, grid)
+    ref = pck_key_scores(q, q_kv, c)
+    assert np.allclose(got, ref, atol=1e-4)
+
+
+def test_cupy_kernel_exact():
+    cp = pytest.importorskip("cupy")
+    try:
+        cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover
+        pytest.skip("no CUDA device")
+    codes, w, bias = _synth(H=32, S=1024, D=128, seed=2)
+    ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
+    got = k2_key_scores(
+        cp.asarray(codes), cp.asarray(w), cp.asarray(bias), cp.asarray(_NF4)
+    )
+    assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-4

--- a/tests/test_volta_k2.py
+++ b/tests/test_volta_k2.py
@@ -246,3 +246,33 @@ def test_cold_partials_integration():
     assert np.allclose(cp.asnumpy(m), m_ref, atol=1e-4)
     assert np.allclose(cp.asnumpy(lsum), l_ref, rtol=1e-4, atol=1e-4)
     assert np.allclose(cp.asnumpy(acc), acc_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_kv_fused_pck_cupy_dispatch():
+    """The dispatched pck_cold_partials (xp=cupy -> K2 kernels, keys with
+    outliers) matches the NumPy reference path bit-for-bit within fp32."""
+    cp = pytest.importorskip("cupy")
+    try:
+        cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover
+        pytest.skip("no CUDA device")
+    H, S, D, Lv = 4, 600, 128, 256
+    rng = np.random.default_rng(24)
+    xk = (0.3 * rng.standard_normal((1, H, S, D))).astype(np.float32)
+    xk[:, :, :, ::9] += 3.0  # magnitude outliers on the keys
+    q_kv = PerChannelKV(head_dim=D, n_heads=H, bits=4, nf4_asym=True, outlier_frac=0.02)
+    kc = q_kv.compress(xk)
+    pi = np.linalg.qr(rng.standard_normal((D, D)))[0].astype(np.float32)
+    cent = np.sort(rng.standard_normal(Lv)).astype(np.float32)
+    tq = SimpleNamespace(_Pi=pi, _Pi_T=pi.T.copy(), centroids=cent, _structured=False)
+    vcodes = rng.integers(0, Lv, size=(H, S, D), dtype=np.uint8)
+    norm_v = (0.5 + rng.random((H, S))).astype(np.float32)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    scale = 1.0 / np.sqrt(D)
+
+    m0, l0, a0 = pck_cold_partials(q, q_kv, kc, vcodes, norm_v, tq, scale, xp=np)
+    m1, l1, a1 = pck_cold_partials(q, q_kv, kc, vcodes, norm_v, tq, scale, xp=cp)
+
+    assert np.allclose(cp.asnumpy(m1), m0, atol=1e-4)
+    assert np.allclose(cp.asnumpy(l1), l0, rtol=1e-4, atol=1e-4)
+    assert np.allclose(cp.asnumpy(a1), a0, rtol=1e-3, atol=1e-3)

--- a/tests/test_volta_k2.py
+++ b/tests/test_volta_k2.py
@@ -9,12 +9,24 @@ torch-optional tests.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
-from turboquant_pro.kv_fused_pck import _grid_params, pck_key_scores
+from turboquant_pro.kv_fused_pck import (
+    _grid_params,
+    build_outlier_csr,
+    pck_cold_partials,
+    pck_key_scores,
+)
 from turboquant_pro.per_channel_kv import _NF4, PerChannelKV, _pack_indices
-from turboquant_pro.volta_kernels import k2_key_scores, k2_key_scores_packed
+from turboquant_pro.volta_kernels import (
+    apply_outlier_csr,
+    k2_key_scores,
+    k2_key_scores_packed,
+    value_accum,
+)
 
 
 def _synth(H=8, S=257, D=128, seed=0):
@@ -133,3 +145,104 @@ def test_packed_cupy_exact():
         bits,
     )
     assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-4
+
+
+# ------------------------------ P4: values + outliers ---------------------- #
+
+
+def test_value_accum_cpu_fallback():
+    H, S, D, Lv = 4, 300, 128, 256
+    rng = np.random.default_rng(20)
+    vcodes = rng.integers(0, Lv, size=(H, S, D), dtype=np.uint8)
+    wv = (0.1 * rng.standard_normal((H, S))).astype(np.float32)
+    cent = np.sort(rng.standard_normal(Lv)).astype(np.float32)
+    got = value_accum(vcodes, wv, cent)
+    ref = np.einsum("hs,hsd->hd", wv, cent[vcodes]).astype(np.float32)
+    assert np.allclose(got, ref, atol=1e-4)
+
+
+def test_value_accum_cupy_exact():
+    cp = pytest.importorskip("cupy")
+    try:
+        cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover
+        pytest.skip("no CUDA device")
+    H, S, D, Lv = 32, 2048, 128, 256
+    rng = np.random.default_rng(21)
+    vcodes = rng.integers(0, Lv, size=(H, S, D), dtype=np.uint8)
+    wv = (0.1 * rng.standard_normal((H, S))).astype(np.float32)
+    cent = np.sort(rng.standard_normal(Lv)).astype(np.float32)
+    ref = np.einsum("hs,hsd->hd", wv, cent[vcodes]).astype(np.float32)
+    got = value_accum(cp.asarray(vcodes), cp.asarray(wv), cp.asarray(cent))
+    rel = float(cp.abs(got - cp.asarray(ref)).max()) / float(np.abs(ref).max())
+    assert rel < 1e-4
+
+
+def test_outlier_csr_cupy_matches_reference():
+    cp = pytest.importorskip("cupy")
+    try:
+        cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover
+        pytest.skip("no CUDA device")
+    H, S, D = 6, 400, 128
+    rng = np.random.default_rng(22)
+    x = (0.3 * rng.standard_normal((1, H, S, D))).astype(np.float32)
+    x[:, :, :, ::9] += 3.0  # create magnitude outliers
+    q_kv = PerChannelKV(head_dim=D, n_heads=H, bits=4, nf4_asym=True, outlier_frac=0.02)
+    c = q_kv.compress(x)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    dense = k2_key_scores(
+        cp.asarray(c.indices[0]),
+        cp.asarray((q * _grid_params(q_kv, c)[1]).astype(np.float32)),
+        cp.asarray((q * _grid_params(q_kv, c)[0]).sum(1).astype(np.float32)),
+        cp.asarray(_grid_params(q_kv, c)[2]),
+    )
+    row_ptr, cols, deltas = build_outlier_csr(q_kv, c)
+    got = apply_outlier_csr(
+        dense, cp.asarray(row_ptr), cp.asarray(cols), cp.asarray(deltas), cp.asarray(q)
+    )
+    ref = pck_key_scores(q, q_kv, c)  # dense + outliers, numpy
+    assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-3
+
+
+def test_cold_partials_integration():
+    """Full fused cold-block decode (per-channel keys + PolarQuant values), built
+    from the K2 kernels, matches ``pck_cold_partials``."""
+    cp = pytest.importorskip("cupy")
+    try:
+        cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover
+        pytest.skip("no CUDA device")
+    H, S, D, Lv = 4, 512, 128, 256
+    rng = np.random.default_rng(23)
+    xk = (0.3 * rng.standard_normal((1, H, S, D))).astype(np.float32)
+    q_kv = PerChannelKV(head_dim=D, n_heads=H, bits=4, nf4_asym=True)
+    kc = q_kv.compress(xk)
+    pi = np.linalg.qr(rng.standard_normal((D, D)))[0].astype(np.float32)
+    cent = np.sort(rng.standard_normal(Lv)).astype(np.float32)
+    tq = SimpleNamespace(_Pi=pi, _Pi_T=pi.T.copy(), centroids=cent, _structured=False)
+    vcodes = rng.integers(0, Lv, size=(H, S, D), dtype=np.uint8)
+    norm_v = (0.5 + rng.random((H, S))).astype(np.float32)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    scale = 1.0 / np.sqrt(D)
+
+    m_ref, l_ref, acc_ref = pck_cold_partials(q, q_kv, kc, vcodes, norm_v, tq, scale)
+
+    mu, weight, kgrid = _grid_params(q_kv, kc)
+    sc = k2_key_scores(
+        cp.asarray(kc.indices[0]),
+        cp.asarray((q * weight).astype(np.float32)),
+        cp.asarray((q * mu).sum(1).astype(np.float32)),
+        cp.asarray(kgrid),
+    )
+    sc = sc * np.float32(scale)
+    m = sc.max(axis=1)
+    e = cp.exp(sc - m[:, None])
+    lsum = e.sum(axis=1)
+    wv = e * cp.asarray(norm_v)
+    acc_code = value_accum(cp.asarray(vcodes), wv, cp.asarray(cent))
+    acc = acc_code @ cp.asarray(pi)
+
+    assert np.allclose(cp.asnumpy(m), m_ref, atol=1e-4)
+    assert np.allclose(cp.asnumpy(lsum), l_ref, rtol=1e-4, atol=1e-4)
+    assert np.allclose(cp.asnumpy(acc), acc_ref, rtol=1e-3, atol=1e-3)

--- a/tests/test_volta_k2.py
+++ b/tests/test_volta_k2.py
@@ -13,8 +13,8 @@ import numpy as np
 import pytest
 
 from turboquant_pro.kv_fused_pck import _grid_params, pck_key_scores
-from turboquant_pro.per_channel_kv import _NF4, PerChannelKV
-from turboquant_pro.volta_kernels import k2_key_scores
+from turboquant_pro.per_channel_kv import _NF4, PerChannelKV, _pack_indices
+from turboquant_pro.volta_kernels import k2_key_scores, k2_key_scores_packed
 
 
 def _synth(H=8, S=257, D=128, seed=0):
@@ -67,5 +67,67 @@ def test_cupy_kernel_exact():
     ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
     got = k2_key_scores(
         cp.asarray(codes), cp.asarray(w), cp.asarray(bias), cp.asarray(_NF4)
+    )
+    assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-4
+
+
+def test_packed_cpu_matches_reference():
+    """Packed decode (CPU fallback) reproduces the unpacked reference for 2/3/4-bit."""
+    for bits in (2, 3, 4):
+        H, S, D = 4, 65, 128
+        rng = np.random.default_rng(10 + bits)
+        codes = rng.integers(0, 2**bits, size=(H, S, D), dtype=np.uint8)
+        q = rng.standard_normal((H, D)).astype(np.float32)
+        weight = (0.5 + rng.random((H, D))).astype(np.float32)
+        w = (q * weight).astype(np.float32)
+        bias = np.zeros(H, dtype=np.float32)
+        grid = np.linspace(-1, 1, 2**bits).astype(np.float32)
+        packed = _pack_indices(codes, bits)
+        got = k2_key_scores_packed(packed, w, bias, grid, H, S, D, bits)
+        ref = bias[:, None] + np.einsum("hd,hsd->hs", w, grid[codes])
+        assert np.allclose(got, ref, atol=1e-5), f"bits={bits}"
+
+
+def test_packed_matches_pck_reference():
+    """Packed path matches ``pck_key_scores`` on a real packed asym-NF4 container."""
+    H, S, D = 5, 130, 128
+    rng = np.random.default_rng(7)
+    x = (0.3 * rng.standard_normal((1, H, S, D))).astype(np.float32)
+    x[:, :, :, ::5] += 1.5
+    q_kv = PerChannelKV(head_dim=D, n_heads=H, bits=4, nf4_asym=True)
+    c = q_kv.compress(x, packed=True)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    mu, weight, grid = _grid_params(q_kv, c)
+    w = (q * weight).astype(np.float32)
+    bias = (q * mu).sum(1).astype(np.float32)
+    got = k2_key_scores_packed(c.indices, w, bias, grid, H, S, D, c.bits)
+    ref = pck_key_scores(q, q_kv, c)
+    assert np.allclose(got, ref, atol=1e-4)
+
+
+def test_packed_cupy_exact():
+    cp = pytest.importorskip("cupy")
+    try:
+        cp.cuda.runtime.getDeviceCount()
+    except Exception:  # pragma: no cover
+        pytest.skip("no CUDA device")
+    H, S, D, bits = 32, 1024, 128, 4
+    rng = np.random.default_rng(3)
+    codes = rng.integers(0, 2**bits, size=(H, S, D), dtype=np.uint8)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    weight = (0.5 + rng.random((H, D))).astype(np.float32)
+    w = (q * weight).astype(np.float32)
+    bias = (0.1 * rng.standard_normal(H)).astype(np.float32)
+    packed = _pack_indices(codes, bits)
+    ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
+    got = k2_key_scores_packed(
+        cp.asarray(packed),
+        cp.asarray(w),
+        cp.asarray(bias),
+        cp.asarray(_NF4),
+        H,
+        S,
+        D,
+        bits,
     )
     assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-4

--- a/tests/test_volta_k2.py
+++ b/tests/test_volta_k2.py
@@ -63,12 +63,14 @@ def test_cupy_kernel_exact():
         cp.cuda.runtime.getDeviceCount()
     except Exception:  # pragma: no cover
         pytest.skip("no CUDA device")
-    codes, w, bias = _synth(H=32, S=1024, D=128, seed=2)
-    ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
-    got = k2_key_scores(
-        cp.asarray(codes), cp.asarray(w), cp.asarray(bias), cp.asarray(_NF4)
-    )
-    assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-4
+    # S a multiple of 4 (tuned vec4+ns4 path) and a non-multiple (tail handling).
+    for S in (1024, 1023):
+        codes, w, bias = _synth(H=32, S=S, D=128, seed=2)
+        ref = bias[:, None] + np.einsum("hd,hsd->hs", w, _NF4[codes])
+        got = k2_key_scores(
+            cp.asarray(codes), cp.asarray(w), cp.asarray(bias), cp.asarray(_NF4)
+        )
+        assert float(cp.abs(got - cp.asarray(ref)).max()) < 1e-4, f"S={S}"
 
 
 def test_packed_cpu_matches_reference():

--- a/turboquant_pro/kv_fused_pck.py
+++ b/turboquant_pro/kv_fused_pck.py
@@ -126,8 +126,18 @@ def build_outlier_csr(q_kv: PerChannelKV, c: CompressedPerChannelKV):
     return row_ptr.reshape(-1)[: H * S + 1], j.astype(np.uint16), deltas
 
 
+def _is_cupy(xp):
+    """True when ``xp`` is the CuPy module (so the K2 kernels are usable)."""
+    return getattr(xp, "__name__", "") == "cupy"
+
+
 def pck_key_scores(q, q_kv: PerChannelKV, c: CompressedPerChannelKV, xp=np):
-    """Fused per-channel key scores (H, S): bias + dense grid sum + CSR deltas."""
+    """Fused per-channel key scores (H, S): bias + dense grid sum + CSR deltas.
+
+    On CuPy the dense sum and the outlier deltas run as the Volta K2 kernels
+    (:mod:`turboquant_pro.volta_kernels`), reading the codes directly with no
+    ``(H,S,D)`` fp32 intermediate; on NumPy the einsum reference runs. Both are
+    exact to fp32 (``tests/test_volta_k2.py``)."""
     B, H, S, D = c.shape
     mu, weight, grid = _grid_params(q_kv, c)
     codes = _codes(c)[0]  # (H, S, D)
@@ -135,8 +145,24 @@ def pck_key_scores(q, q_kv: PerChannelKV, c: CompressedPerChannelKV, xp=np):
     w = qf * xp.asarray(weight)  # (H, D) per-channel table weights
     bias = (qf * xp.asarray(mu)).sum(axis=1)  # (H,) zero-point term, folded
     g = xp.asarray(grid, dtype=xp.float32)
-    scores = xp.einsum("hd,hsd->hs", w, g[xp.asarray(codes)]) + bias[:, None]
 
+    if _is_cupy(xp):
+        from .volta_kernels import apply_outlier_csr, k2_key_scores
+
+        scores = k2_key_scores(xp.asarray(codes), w, bias, g)
+        csr = build_outlier_csr(q_kv, c)
+        if csr is not None:
+            row_ptr, cols, deltas = csr
+            scores = apply_outlier_csr(
+                scores,
+                xp.asarray(row_ptr),
+                xp.asarray(cols),
+                xp.asarray(deltas),
+                qf,
+            )
+        return scores
+
+    scores = xp.einsum("hd,hsd->hs", w, g[xp.asarray(codes)]) + bias[:, None]
     csr = build_outlier_csr(q_kv, c)
     if csr is not None:
         row_ptr, cols, deltas = csr
@@ -161,9 +187,13 @@ def pck_cold_partials(q, q_kv, kc, vcodes, norm_v, tq, scale, xp=np):
     m = sc.max(axis=1)
     e = xp.exp(sc - m[:, None])
     lsum = e.sum(axis=1)
-    acc_code = xp.einsum(
-        "hs,hsd->hd", e * xp.asarray(norm_v, dtype=xp.float32), cent[vcodes]
-    )
+    wv = e * xp.asarray(norm_v, dtype=xp.float32)
+    if _is_cupy(xp):
+        from .volta_kernels import value_accum
+
+        acc_code = value_accum(xp.asarray(vcodes), wv, cent)
+    else:
+        acc_code = xp.einsum("hs,hsd->hd", wv, cent[vcodes])
     return m, lsum, acc_code @ pi
 
 

--- a/turboquant_pro/volta_kernels.py
+++ b/turboquant_pro/volta_kernels.py
@@ -20,11 +20,15 @@ touched is the codes themselves (2x smaller than fp16 K here; 4x once packed).
 
 Why Volta specifically: the score is a per-channel-coded GEMV -- memory-bound at
 decode -- so the win is *bandwidth*, not tensor cores. The GV100 has no
-``cp.async``/``ldmatrix`` and none are needed. The kernel is one warp per
-``(h, s)``: 32 lanes stride the head dimension (coalesced byte reads), the NF4
-grid lives in shared memory, and a warp shuffle reduces the partial dot. Measured
-on a Quadro GV100 vs decompress-then-attend: ~12--20x at ``S in {4k, 8k}``,
-exact to fp32 rounding.
+``cp.async``/``ldmatrix`` and none are needed. The tuned kernel
+(``_KERNEL_SRC_VEC4NS``, default when ``D % 4 == 0``) is one warp per group of
+four ``s`` rows: each lane reads a ``uint32`` (4 codes) for one coalesced 128B
+transaction and keeps four independent rows in flight for latency-hiding
+memory-level parallelism, the NF4 grid lives in shared memory, and a warp shuffle
+reduces each row's dot. That reaches ~55--63% of HBM2 peak (1.6--1.9x over the
+one-warp-per-``(h,s)`` scalar kernel, kept as the odd-``D`` fallback). Measured on
+a Quadro GV100 vs decompress-then-attend: ~15--30x at ``S in {4k..16k}``, exact
+to fp32 rounding.
 
 Compiled lazily via CuPy's NVRTC (arch auto = ``compute_70`` on a GV100), so the
 import is free on CPU-only hosts; a NumPy reference is used when CuPy is absent.
@@ -77,6 +81,67 @@ void k2_key_scores_u8(
     for (int off = 16; off > 0; off >>= 1)
         acc += __shfl_down_sync(0xffffffffu, acc, off);
     if (lane == 0) scores[(long)h * S + s] = acc + bias[h];
+}
+"""
+
+# Tuned unpacked kernel (default when D % 4 == 0). Two changes over the scalar
+# kernel take it from ~34% to ~60% of HBM2 peak on a GV100 (1.6--1.9x): (1) each
+# lane reads a ``uint32`` (4 codes) -> one coalesced 128B transaction per warp
+# instead of four 32B ones; (2) each warp handles NS=4 independent ``s`` rows, so
+# 4 loads are in flight before any reduction -- the memory-level parallelism that
+# hides latency (the actual bottleneck; vectorization alone barely helped). NS=8
+# gave nothing over 4. Bounds-checked, so S need not be a multiple of NS.
+_KERNEL_SRC_VEC4NS = r"""
+extern "C" __global__
+void k2_key_scores_vec4ns(
+    const unsigned int* __restrict__ codes32,  // (H,S,D/4) uint8 codes as uint32
+    const float* __restrict__ w,               // (H,D) = q * weight
+    const float* __restrict__ bias,            // (H,)
+    const float* __restrict__ grid,            // (L,) codebook
+    float* __restrict__ scores,                // (H,S)
+    int H, int S, int D, int L)
+{
+    const int NS = 4;
+    __shared__ float sgrid[64];
+    int tid = threadIdx.x;
+    int lane = tid & 31;
+    int warps_per_block = blockDim.x >> 5;
+    for (int i = tid; i < L; i += blockDim.x) sgrid[i] = grid[i];
+    __syncthreads();
+
+    int SN = (S + NS - 1) / NS;                 // s-groups per head
+    long g = (long)blockIdx.x * warps_per_block + (tid >> 5);
+    if (g >= (long)H * SN) return;
+    int h = (int)(g / SN);
+    int s0 = (int)(g % SN) * NS;
+    int nv = S - s0;
+    if (nv > NS) nv = NS;                        // valid rows in this group
+    int D4 = D >> 2;
+    const float* wrow = w + (long)h * D;
+    float acc[NS];
+    #pragma unroll
+    for (int i = 0; i < NS; i++) acc[i] = 0.f;
+    for (int t = lane; t < D4; t += 32) {
+        int d = t << 2;
+        float w0 = wrow[d], w1 = wrow[d + 1], w2 = wrow[d + 2], w3 = wrow[d + 3];
+        #pragma unroll
+        for (int i = 0; i < NS; i++) {
+            if (i < nv) {
+                unsigned int wd = codes32[((long)h * S + s0 + i) * D4 + t];
+                acc[i] += w0 * sgrid[wd & 0xff] + w1 * sgrid[(wd >> 8) & 0xff]
+                        + w2 * sgrid[(wd >> 16) & 0xff] + w3 * sgrid[(wd >> 24) & 0xff];
+            }
+        }
+    }
+    #pragma unroll
+    for (int i = 0; i < NS; i++) {
+        if (i < nv) {
+            float a = acc[i];
+            for (int off = 16; off > 0; off >>= 1)
+                a += __shfl_down_sync(0xffffffffu, a, off);
+            if (lane == 0) scores[(long)h * S + s0 + i] = a + bias[h];
+        }
+    }
 }
 """
 
@@ -238,12 +303,20 @@ def k2_key_scores(codes, w, bias, grid, out=None):
         out = cp.empty((H, S), dtype=cp.float32)
     tpb = 256
     warps_per_block = tpb // 32
-    grid_x = (H * S + warps_per_block - 1) // warps_per_block
-    _get_kernel("k2_key_scores_u8", _KERNEL_SRC)(
-        (grid_x,),
-        (tpb,),
-        (codes, w, bias, grid, out, np.int32(H), np.int32(S), np.int32(D), np.int32(L)),
-    )
+    args = (np.int32(H), np.int32(S), np.int32(D), np.int32(L))
+    if D % 4 == 0:
+        # tuned path: uint32 loads + NS=4 s-rows/warp (see _KERNEL_SRC_VEC4NS)
+        codes32 = codes.view(cp.uint32)  # (H, S, D/4)
+        sn = (S + 3) // 4
+        grid_x = (H * sn + warps_per_block - 1) // warps_per_block
+        _get_kernel("k2_key_scores_vec4ns", _KERNEL_SRC_VEC4NS)(
+            (grid_x,), (tpb,), (codes32, w, bias, grid, out, *args)
+        )
+    else:
+        grid_x = (H * S + warps_per_block - 1) // warps_per_block
+        _get_kernel("k2_key_scores_u8", _KERNEL_SRC)(
+            (grid_x,), (tpb,), (codes, w, bias, grid, out, *args)
+        )
     return out
 
 

--- a/turboquant_pro/volta_kernels.py
+++ b/turboquant_pro/volta_kernels.py
@@ -191,16 +191,20 @@ void k2_key_scores_packed(
 }
 """
 
-# Fast bits=4 path: a 256-entry format-decode LUT (byte -> its two 4-bit codes)
-# plus contiguous channel-pair assignment, so each byte is read once (coalesced)
-# and decoded with a table lookup instead of per-bit reconstruction. Requires
-# ``D % 64 == 0`` (two codes per byte, D/32 channels per lane). At parity with the
-# unpacked kernel while touching half the bytes -- K2 is latency-bound, so packing
-# is a storage win (half the KV cache) at ~equal decode speed, not a speedup.
+# Fast bits=4 path (default when D % 4 == 0). The same vec+ns4 recipe as the
+# unpacked kernel, adapted to packed bytes: each lane reads a ``uint16`` (2 bytes
+# = 4 codes) per row for one coalesced load, a 256-entry format-decode LUT turns
+# each byte into its two codes, and NS=4 ``s`` rows stay in flight (MLP). This is
+# ~1.5x faster than the naive one-warp-per-(h,s) LUT kernel and reaches near
+# parity (~0.85-0.98x) with the unpacked kernel. Note packing is still a *storage*
+# win (half the KV cache) at ~parity decode, not a speedup: a D=128 packed row is
+# only 64B, half a 128B transaction, so it cannot become bandwidth-bound the way
+# unpacked (uint32, full 128B line) does. Requires ``D % 4 == 0`` (uint16 view,
+# 4 channels per word); other cases use the general per-bit kernel.
 _KERNEL_SRC_PACKED4 = r"""
 extern "C" __global__
 void k2_key_scores_packed4(
-    const unsigned char* __restrict__ packed,  // 4-bit packed codes
+    const unsigned short* __restrict__ p16,    // 4-bit packed codes as uint16
     const short* __restrict__ codeLUT,         // byte -> code_even | code_odd<<8
     const float* __restrict__ w,               // (H,D)
     const float* __restrict__ bias,            // (H,)
@@ -208,6 +212,7 @@ void k2_key_scores_packed4(
     float* __restrict__ scores,                // (H,S)
     int H, int S, int D, int L)
 {
+    const int NS = 4;
     __shared__ float sgrid[64];
     int tid = threadIdx.x;
     int lane = tid & 31;
@@ -215,24 +220,40 @@ void k2_key_scores_packed4(
     for (int i = tid; i < L; i += blockDim.x) sgrid[i] = grid[i];
     __syncthreads();
 
-    long gwarp = (long)blockIdx.x * warps_per_block + (tid >> 5);
-    if (gwarp >= (long)H * S) return;
-    int h = (int)(gwarp / S);
-    int s = (int)(gwarp % S);
-    long rb = ((long)h * S + s) * D;
+    int SN = (S + NS - 1) / NS;
+    long g = (long)blockIdx.x * warps_per_block + (tid >> 5);
+    if (g >= (long)H * SN) return;
+    int h = (int)(g / SN);
+    int s0 = (int)(g % SN) * NS;
+    int nv = S - s0;
+    if (nv > NS) nv = NS;
+    int U = D >> 2;                 // uint16 words per row (4 codes each)
     const float* wrow = w + (long)h * D;
-    int cpl = D >> 5;             // channels per lane
-    int d0 = lane * cpl;
-    long b0 = (rb + d0) >> 1;     // byte holding the lane's first channel pair
-    float acc = 0.f;
-    for (int j = 0; j < cpl; j += 2) {
-        int cc = codeLUT[packed[b0 + (j >> 1)]];
-        acc += wrow[d0 + j] * sgrid[cc & 0xff]
-             + wrow[d0 + j + 1] * sgrid[(cc >> 8) & 0xff];
+    float acc[NS];
+    #pragma unroll
+    for (int i = 0; i < NS; i++) acc[i] = 0.f;
+    for (int u = lane; u < U; u += 32) {
+        int d0 = u << 2;
+        float w0 = wrow[d0], w1 = wrow[d0 + 1], w2 = wrow[d0 + 2], w3 = wrow[d0 + 3];
+        #pragma unroll
+        for (int i = 0; i < NS; i++) {
+            if (i < nv) {
+                unsigned short v = p16[((long)h * S + s0 + i) * U + u];
+                int lo = codeLUT[v & 0xff], hi = codeLUT[(v >> 8) & 0xff];
+                acc[i] += w0 * sgrid[lo & 0xff] + w1 * sgrid[(lo >> 8) & 0xff]
+                        + w2 * sgrid[hi & 0xff] + w3 * sgrid[(hi >> 8) & 0xff];
+            }
+        }
     }
-    for (int off = 16; off > 0; off >>= 1)
-        acc += __shfl_down_sync(0xffffffffu, acc, off);
-    if (lane == 0) scores[(long)h * S + s] = acc + bias[h];
+    #pragma unroll
+    for (int i = 0; i < NS; i++) {
+        if (i < nv) {
+            float a = acc[i];
+            for (int off = 16; off > 0; off >>= 1)
+                a += __shfl_down_sync(0xffffffffu, a, off);
+            if (lane == 0) scores[(long)h * S + s0 + i] = a + bias[h];
+        }
+    }
 }
 """
 
@@ -364,13 +385,16 @@ def k2_key_scores_packed(packed, w, bias, grid, H, S, D, bits, out=None):
         out = cp.empty((H, S), dtype=cp.float32)
     tpb = 256
     warps_per_block = tpb // 32
-    grid_x = (H * S + warps_per_block - 1) // warps_per_block
-    if bits == 4 and D % 64 == 0:
+    if bits == 4 and D % 4 == 0:
+        # tuned path: uint16 loads + LUT + NS=4 s-rows/warp (_KERNEL_SRC_PACKED4)
+        p16 = packed.view(cp.uint16)
+        sn = (S + 3) // 4
+        grid_x = (H * sn + warps_per_block - 1) // warps_per_block
         _get_kernel("k2_key_scores_packed4", _KERNEL_SRC_PACKED4)(
             (grid_x,),
             (tpb,),
             (
-                packed,
+                p16,
                 _get_code_lut(),
                 w,
                 bias,
@@ -383,6 +407,7 @@ def k2_key_scores_packed(packed, w, bias, grid, H, S, D, bits, out=None):
             ),
         )
     else:
+        grid_x = (H * S + warps_per_block - 1) // warps_per_block
         _get_kernel("k2_key_scores_packed", _KERNEL_SRC_PACKED)(
             (grid_x,),
             (tpb,),

--- a/turboquant_pro/volta_kernels.py
+++ b/turboquant_pro/volta_kernels.py
@@ -46,7 +46,13 @@ except ImportError:  # pragma: no cover - exercised on CPU-only hosts
     cp = None  # type: ignore[assignment]
     _HAS_CUPY = False
 
-__all__ = ["k2_key_scores", "k2_key_scores_packed", "K2_MAX_LEVELS"]
+__all__ = [
+    "k2_key_scores",
+    "k2_key_scores_packed",
+    "value_accum",
+    "apply_outlier_csr",
+    "K2_MAX_LEVELS",
+]
 
 # The shared-memory grid buffer is sized for this many codebook levels (covers
 # 2/3/4-bit uniform and NF4). Raising it means widening ``sgrid`` in the source.
@@ -425,3 +431,150 @@ def k2_key_scores_packed(packed, w, bias, grid, H, S, D, bits, out=None):
             ),
         )
     return out
+
+
+# ---------------------------------------------------------------------------- #
+# Values leg (P4): the transpose of the key score. PolarQuant values enter the  #
+# decode as  acc_code[h,d] = sum_s wv[h,s] * cent[vcode[h,s,d]]  (wv = e*norm_v, #
+# cent a scalar codebook). The cupy path materializes cent[vcodes] (H,S,d) fp32; #
+# this kernel reads vcodes (uint8) directly. Block per (h, s-chunk); thread per  #
+# d so vcodes reads coalesce; S split across blocks with atomicAdd for occupancy #
+# (SCH=128 measured best on a GV100). ~13-17x over the cupy einsum.              #
+# ---------------------------------------------------------------------------- #
+_KERNEL_SRC_VALUE = r"""
+extern "C" __global__
+void value_accum(
+    const unsigned char* __restrict__ vcodes,  // (H,S,D)
+    const float* __restrict__ wv,              // (H,S) = e * norm_v
+    const float* __restrict__ cent,            // (Lv,) scalar codebook
+    float* __restrict__ acc,                   // (H,D), pre-zeroed
+    int H, int S, int D, int Lv, int SCH)
+{
+    __shared__ float scent[256];
+    for (int i = threadIdx.x; i < Lv; i += blockDim.x) scent[i] = cent[i];
+    __syncthreads();
+    int h = blockIdx.x;
+    int d = threadIdx.x;
+    if (d >= D) return;
+    int s0 = blockIdx.y * SCH;
+    int s1 = s0 + SCH;
+    if (s1 > S) s1 = S;
+    const unsigned char* base = vcodes + (long)h * S * D + d;
+    const float* wrow = wv + (long)h * S;
+    float a = 0.f;
+    for (int s = s0; s < s1; s++) a += wrow[s] * scent[base[(long)s * D]];
+    atomicAdd(&acc[(long)h * D + d], a);
+}
+"""
+
+# Key outlier deltas (P4): dense-and-sparse keeps the top magnitude entries in
+# fp16; build_outlier_csr turns them into token-major score deltas. This applies
+# them on-GPU: one thread per (h,s) row adds sum_k q[h, cols[k]] * deltas[k].
+_KERNEL_SRC_OUTLIER = r"""
+extern "C" __global__
+void apply_outlier_csr(
+    const int* __restrict__ row_ptr,           // (H*S + 1,)
+    const unsigned short* __restrict__ cols,    // (nnz,) channel index
+    const float* __restrict__ deltas,           // (nnz,)
+    const float* __restrict__ q,                // (H,D)
+    float* __restrict__ scores,                 // (H,S) in/out
+    int H, int S, int D)
+{
+    long row = (long)blockIdx.x * blockDim.x + threadIdx.x;  // = h*S + s
+    if (row >= (long)H * S) return;
+    int a = row_ptr[row];
+    int b = row_ptr[row + 1];
+    if (a == b) return;
+    const float* qh = q + (row / S) * D;
+    float corr = 0.f;
+    for (int k = a; k < b; k++) corr += qh[cols[k]] * deltas[k];
+    scores[row] += corr;
+}
+"""
+
+
+def value_accum(vcodes, wv, cent, out=None, s_chunk=128):
+    """Fused PolarQuant value accumulation ``acc_code[h,d] = sum_s wv * cent[vcode]``.
+
+    Args:
+        vcodes: ``(H, S, D)`` uint8 value codes.
+        wv:     ``(H, S)`` float32 per-token weights (``e * norm_v``).
+        cent:   ``(Lv,)`` float32 scalar codebook (``Lv <= 256``).
+        out:    optional ``(H, D)`` float32 accumulator (CuPy path only).
+        s_chunk: rows of ``S`` per block (occupancy knob; 128 best on GV100).
+
+    Returns ``(H, D)`` float32 (rotate to real space with ``@ pi`` afterward).
+    On CuPy inputs runs the kernel; otherwise the NumPy reference.
+    """
+    H, S, D = vcodes.shape
+    Lv = int(cent.shape[0])
+    if Lv > 256:
+        raise ValueError(f"cent has {Lv} levels; value kernel caps at 256")
+    if wv.shape != (H, S):
+        raise ValueError(f"wv must be (H,S)=({H},{S}), got {tuple(wv.shape)}")
+
+    if not (_HAS_CUPY and isinstance(vcodes, cp.ndarray)):
+        return np.einsum(
+            "hs,hsd->hd", np.asarray(wv), np.asarray(cent)[np.asarray(vcodes)]
+        ).astype(np.float32)
+
+    vcodes = cp.ascontiguousarray(vcodes, dtype=cp.uint8)
+    wv = cp.ascontiguousarray(wv, dtype=cp.float32)
+    cent = cp.ascontiguousarray(cent, dtype=cp.float32)
+    if out is None:
+        out = cp.zeros((H, D), dtype=cp.float32)
+    else:
+        out.fill(0)
+    n_chunks = (S + s_chunk - 1) // s_chunk
+    _get_kernel("value_accum", _KERNEL_SRC_VALUE)(
+        (H, n_chunks),
+        (D,),
+        (
+            vcodes,
+            wv,
+            cent,
+            out,
+            np.int32(H),
+            np.int32(S),
+            np.int32(D),
+            np.int32(Lv),
+            np.int32(s_chunk),
+        ),
+    )
+    return out
+
+
+def apply_outlier_csr(scores, row_ptr, cols, deltas, q):
+    """Add key dense-and-sparse outlier score deltas in place: ``scores[h,s] +=
+    sum_k q[h, cols[k]] * deltas[k]`` over CSR row ``h*S + s``.
+
+    ``row_ptr`` ``(H*S+1,)`` int32, ``cols`` ``(nnz,)`` uint16, ``deltas``
+    ``(nnz,)`` float32 -- the output of ``kv_fused_pck.build_outlier_csr``.
+    ``scores`` ``(H, S)`` and ``q`` ``(H, D)``. Returns ``scores``.
+    """
+    H, S = scores.shape
+    D = q.shape[1]
+    if not (_HAS_CUPY and isinstance(scores, cp.ndarray)):
+        rp = np.asarray(row_ptr)
+        rows = np.repeat(np.arange(H * S), np.diff(rp))
+        heads = rows // S
+        contrib = np.asarray(q, dtype=np.float64)[
+            heads, np.asarray(cols, dtype=np.int64)
+        ] * np.asarray(deltas, dtype=np.float64)
+        corr = np.zeros(H * S, dtype=np.float64)
+        np.add.at(corr, rows, contrib)
+        return scores + corr.reshape(H, S).astype(scores.dtype)
+
+    scores = cp.ascontiguousarray(scores, dtype=cp.float32)
+    row_ptr = cp.ascontiguousarray(row_ptr, dtype=cp.int32)
+    cols = cp.ascontiguousarray(cols, dtype=cp.uint16)
+    deltas = cp.ascontiguousarray(deltas, dtype=cp.float32)
+    q = cp.ascontiguousarray(q, dtype=cp.float32)
+    tpb = 256
+    grid_x = (H * S + tpb - 1) // tpb
+    _get_kernel("apply_outlier_csr", _KERNEL_SRC_OUTLIER)(
+        (grid_x,),
+        (tpb,),
+        (row_ptr, cols, deltas, q, scores, np.int32(H), np.int32(S), np.int32(D)),
+    )
+    return scores

--- a/turboquant_pro/volta_kernels.py
+++ b/turboquant_pro/volta_kernels.py
@@ -1,0 +1,143 @@
+# TurboQuant Pro: Volta-native fused KV-decode kernels.
+# Copyright (c) 2026 Andrew H. Bond. MIT License.
+"""Volta (``sm_70``) fused kernels for KV attention-on-codes decode (**K2**).
+
+The recommended *keys* format is
+:class:`~turboquant_pro.per_channel_kv.PerChannelKV` (per-channel asym-NF4). Keys
+enter attention only through ``q . k``, so the whole score can be computed from
+the codes without ever materializing an fp16/fp32 key tensor:
+
+    score[h,s] = bias[h] + sum_d w[h,d] * grid[code[h,s,d]]
+        w    = q * per-channel weight   (H, D)
+        bias = sum_d q * per-channel mu  (H,)   -- zero-point term, folded
+        grid = the NF4 / uniform codebook (L,)
+
+:mod:`turboquant_pro.kv_fused_pck` expresses this with ``einsum(w, grid[codes])``,
+which is correct but materializes ``grid[codes]`` -- an ``(H,S,D)`` fp32 tensor,
+the same bandwidth as decompressing. This module instead reads the 1-byte codes
+directly and does the LUT-dequant + dot in registers, so the only large tensor
+touched is the codes themselves (2x smaller than fp16 K here; 4x once packed).
+
+Why Volta specifically: the score is a per-channel-coded GEMV -- memory-bound at
+decode -- so the win is *bandwidth*, not tensor cores. The GV100 has no
+``cp.async``/``ldmatrix`` and none are needed. The kernel is one warp per
+``(h, s)``: 32 lanes stride the head dimension (coalesced byte reads), the NF4
+grid lives in shared memory, and a warp shuffle reduces the partial dot. Measured
+on a Quadro GV100 vs decompress-then-attend: ~12--20x at ``S in {4k, 8k}``,
+exact to fp32 rounding.
+
+Compiled lazily via CuPy's NVRTC (arch auto = ``compute_70`` on a GV100), so the
+import is free on CPU-only hosts; a NumPy reference is used when CuPy is absent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import cupy as cp  # type: ignore[import-untyped]
+
+    _HAS_CUPY = True
+except ImportError:  # pragma: no cover - exercised on CPU-only hosts
+    cp = None  # type: ignore[assignment]
+    _HAS_CUPY = False
+
+__all__ = ["k2_key_scores", "K2_MAX_LEVELS"]
+
+# The shared-memory grid buffer is sized for this many codebook levels (covers
+# 2/3/4-bit uniform and NF4). Raising it means widening ``sgrid`` in the source.
+K2_MAX_LEVELS = 64
+
+_KERNEL_SRC = r"""
+extern "C" __global__
+void k2_key_scores_u8(
+    const unsigned char* __restrict__ codes,  // (H,S,D) uint8 indices in [0,L)
+    const float* __restrict__ w,              // (H,D) = q * weight
+    const float* __restrict__ bias,           // (H,)
+    const float* __restrict__ grid,           // (L,) codebook
+    float* __restrict__ scores,               // (H,S)
+    int H, int S, int D, int L)
+{
+    __shared__ float sgrid[64];
+    int tid = threadIdx.x;
+    int lane = tid & 31;
+    int warps_per_block = blockDim.x >> 5;
+    for (int i = tid; i < L; i += blockDim.x) sgrid[i] = grid[i];
+    __syncthreads();
+
+    long gwarp = (long)blockIdx.x * warps_per_block + (tid >> 5);
+    long total = (long)H * S;
+    if (gwarp >= total) return;
+    int h = (int)(gwarp / S);
+    int s = (int)(gwarp % S);
+    const unsigned char* crow = codes + ((long)h * S + s) * D;
+    const float* wrow = w + (long)h * D;
+    float acc = 0.f;
+    for (int d = lane; d < D; d += 32) acc += wrow[d] * sgrid[crow[d]];
+    for (int off = 16; off > 0; off >>= 1)
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    if (lane == 0) scores[(long)h * S + s] = acc + bias[h];
+}
+"""
+
+_kernel = None
+
+
+def _get_kernel():
+    global _kernel
+    if _kernel is None:
+        if not _HAS_CUPY:  # pragma: no cover
+            raise RuntimeError("k2_key_scores requires CuPy on a CUDA device")
+        _kernel = cp.RawKernel(_KERNEL_SRC, "k2_key_scores_u8")
+    return _kernel
+
+
+def _reference(codes, w, bias, grid):
+    """NumPy reference: bias + sum_d w * grid[codes]. Also the CPU fallback."""
+    return bias[:, None] + np.einsum("hd,hsd->hs", w, grid[codes])
+
+
+def k2_key_scores(codes, w, bias, grid, out=None):
+    """Fused per-channel key scores ``(H, S)`` from unpacked uint8 codes.
+
+    Args:
+        codes: ``(H, S, D)`` uint8 index array, values in ``[0, len(grid))``.
+        w:     ``(H, D)`` float32, the per-channel table weights ``q * weight``.
+        bias:  ``(H,)`` float32, the folded zero-point term ``sum_d q * mu``.
+        grid:  ``(L,)`` float32 codebook, ``L <= K2_MAX_LEVELS``.
+        out:   optional ``(H, S)`` float32 output buffer (CuPy path only).
+
+    Returns a ``(H, S)`` float32 array on the same backend as the inputs
+    (CuPy when the inputs are CuPy arrays, else NumPy via the reference). The
+    dense path only; outlier CSR deltas (:func:`kv_fused_pck.build_outlier_csr`)
+    are added by the caller.
+    """
+    H, S, D = codes.shape
+    L = int(grid.shape[0])
+    if L > K2_MAX_LEVELS:
+        raise ValueError(f"grid has {L} levels; kernel caps at {K2_MAX_LEVELS}")
+    if w.shape != (H, D):
+        raise ValueError(f"w must be (H,D)=({H},{D}), got {tuple(w.shape)}")
+    if bias.shape != (H,):
+        raise ValueError(f"bias must be (H,)=({H},), got {tuple(bias.shape)}")
+
+    if not (_HAS_CUPY and isinstance(codes, cp.ndarray)):
+        return _reference(
+            np.asarray(codes), np.asarray(w), np.asarray(bias), np.asarray(grid)
+        )
+
+    codes = cp.ascontiguousarray(codes, dtype=cp.uint8)
+    w = cp.ascontiguousarray(w, dtype=cp.float32)
+    bias = cp.ascontiguousarray(bias, dtype=cp.float32)
+    grid = cp.ascontiguousarray(grid, dtype=cp.float32)
+    if out is None:
+        out = cp.empty((H, S), dtype=cp.float32)
+    tpb = 256
+    warps_per_block = tpb // 32
+    grid_x = (H * S + warps_per_block - 1) // warps_per_block
+    _get_kernel()(
+        (grid_x,),
+        (tpb,),
+        (codes, w, bias, grid, out, np.int32(H), np.int32(S), np.int32(D), np.int32(L)),
+    )
+    return out

--- a/turboquant_pro/volta_kernels.py
+++ b/turboquant_pro/volta_kernels.py
@@ -42,7 +42,7 @@ except ImportError:  # pragma: no cover - exercised on CPU-only hosts
     cp = None  # type: ignore[assignment]
     _HAS_CUPY = False
 
-__all__ = ["k2_key_scores", "K2_MAX_LEVELS"]
+__all__ = ["k2_key_scores", "k2_key_scores_packed", "K2_MAX_LEVELS"]
 
 # The shared-memory grid buffer is sized for this many codebook levels (covers
 # 2/3/4-bit uniform and NF4). Raising it means widening ``sgrid`` in the source.
@@ -80,16 +80,120 @@ void k2_key_scores_u8(
 }
 """
 
-_kernel = None
+# Packed variant: codes are bit-packed exactly as ``per_channel_kv._pack_indices``
+# (value i occupies stream bits [i*bits, i*bits+bits); each stream bit lives
+# MSB-first within its byte -- the inverse of ``_unpack_indices``). Reads
+# ``bits/8`` byte per value instead of 1, halving DRAM traffic at 4-bit.
+_KERNEL_SRC_PACKED = r"""
+extern "C" __global__
+void k2_key_scores_packed(
+    const unsigned char* __restrict__ packed,  // bit-packed codes (_pack_indices)
+    const float* __restrict__ w,               // (H,D) = q * weight
+    const float* __restrict__ bias,            // (H,)
+    const float* __restrict__ grid,            // (L,) codebook
+    float* __restrict__ scores,                // (H,S)
+    int H, int S, int D, int L, int bits)
+{
+    __shared__ float sgrid[64];
+    int tid = threadIdx.x;
+    int lane = tid & 31;
+    int warps_per_block = blockDim.x >> 5;
+    for (int i = tid; i < L; i += blockDim.x) sgrid[i] = grid[i];
+    __syncthreads();
+
+    long gwarp = (long)blockIdx.x * warps_per_block + (tid >> 5);
+    long total = (long)H * S;
+    if (gwarp >= total) return;
+    int h = (int)(gwarp / S);
+    int s = (int)(gwarp % S);
+    long rowbase = ((long)h * S + s) * D;  // value index of channel d=0
+    const float* wrow = w + (long)h * D;
+    float acc = 0.f;
+    for (int d = lane; d < D; d += 32) {
+        long g0 = (rowbase + d) * bits;    // first stream bit of this value
+        int code = 0;
+        for (int k = 0; k < bits; k++) {
+            long g = g0 + k;
+            int byte = packed[g >> 3];
+            int bit = (byte >> (7 - (int)(g & 7))) & 1;
+            code |= bit << k;
+        }
+        acc += wrow[d] * sgrid[code];
+    }
+    for (int off = 16; off > 0; off >>= 1)
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    if (lane == 0) scores[(long)h * S + s] = acc + bias[h];
+}
+"""
+
+# Fast bits=4 path: a 256-entry format-decode LUT (byte -> its two 4-bit codes)
+# plus contiguous channel-pair assignment, so each byte is read once (coalesced)
+# and decoded with a table lookup instead of per-bit reconstruction. Requires
+# ``D % 64 == 0`` (two codes per byte, D/32 channels per lane). At parity with the
+# unpacked kernel while touching half the bytes -- K2 is latency-bound, so packing
+# is a storage win (half the KV cache) at ~equal decode speed, not a speedup.
+_KERNEL_SRC_PACKED4 = r"""
+extern "C" __global__
+void k2_key_scores_packed4(
+    const unsigned char* __restrict__ packed,  // 4-bit packed codes
+    const short* __restrict__ codeLUT,         // byte -> code_even | code_odd<<8
+    const float* __restrict__ w,               // (H,D)
+    const float* __restrict__ bias,            // (H,)
+    const float* __restrict__ grid,            // (L,)
+    float* __restrict__ scores,                // (H,S)
+    int H, int S, int D, int L)
+{
+    __shared__ float sgrid[64];
+    int tid = threadIdx.x;
+    int lane = tid & 31;
+    int warps_per_block = blockDim.x >> 5;
+    for (int i = tid; i < L; i += blockDim.x) sgrid[i] = grid[i];
+    __syncthreads();
+
+    long gwarp = (long)blockIdx.x * warps_per_block + (tid >> 5);
+    if (gwarp >= (long)H * S) return;
+    int h = (int)(gwarp / S);
+    int s = (int)(gwarp % S);
+    long rb = ((long)h * S + s) * D;
+    const float* wrow = w + (long)h * D;
+    int cpl = D >> 5;             // channels per lane
+    int d0 = lane * cpl;
+    long b0 = (rb + d0) >> 1;     // byte holding the lane's first channel pair
+    float acc = 0.f;
+    for (int j = 0; j < cpl; j += 2) {
+        int cc = codeLUT[packed[b0 + (j >> 1)]];
+        acc += wrow[d0 + j] * sgrid[cc & 0xff]
+             + wrow[d0 + j + 1] * sgrid[(cc >> 8) & 0xff];
+    }
+    for (int off = 16; off > 0; off >>= 1)
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    if (lane == 0) scores[(long)h * S + s] = acc + bias[h];
+}
+"""
+
+_kernels: dict = {}
+_code_lut = None  # lazily built cupy int16 array, format-decode only (grid-free)
 
 
-def _get_kernel():
-    global _kernel
-    if _kernel is None:
+def _get_code_lut():
+    """byte -> (code_even | code_odd<<8) for the 4-bit ``_pack_indices`` layout."""
+    global _code_lut
+    if _code_lut is None:
+        lut = np.zeros(256, dtype=np.int16)
+        for b in range(256):
+            ce = sum(((b >> (7 - k)) & 1) << k for k in range(4))
+            co = sum(((b >> (3 - k)) & 1) << k for k in range(4))
+            lut[b] = ce | (co << 8)
+        _code_lut = cp.asarray(lut)
+    return _code_lut
+
+
+def _get_kernel(name, src):
+    if name not in _kernels:
         if not _HAS_CUPY:  # pragma: no cover
-            raise RuntimeError("k2_key_scores requires CuPy on a CUDA device")
-        _kernel = cp.RawKernel(_KERNEL_SRC, "k2_key_scores_u8")
-    return _kernel
+            raise RuntimeError("k2 kernels require CuPy on a CUDA device")
+        _kernels[name] = cp.RawKernel(src, name)
+    return _kernels[name]
 
 
 def _reference(codes, w, bias, grid):
@@ -135,9 +239,91 @@ def k2_key_scores(codes, w, bias, grid, out=None):
     tpb = 256
     warps_per_block = tpb // 32
     grid_x = (H * S + warps_per_block - 1) // warps_per_block
-    _get_kernel()(
+    _get_kernel("k2_key_scores_u8", _KERNEL_SRC)(
         (grid_x,),
         (tpb,),
         (codes, w, bias, grid, out, np.int32(H), np.int32(S), np.int32(D), np.int32(L)),
     )
+    return out
+
+
+def _unpack_ref(packed, H, S, D, bits):
+    """NumPy unpack matching ``per_channel_kv._unpack_indices`` (CPU fallback)."""
+    n = H * S * D
+    bitstream = np.unpackbits(np.asarray(packed, dtype=np.uint8))[: n * bits]
+    bitstream = bitstream.reshape(n, bits)
+    weights = (1 << np.arange(bits, dtype=np.uint16)).astype(np.uint16)
+    idx = (bitstream.astype(np.uint16) * weights).sum(axis=1).astype(np.uint8)
+    return idx.reshape(H, S, D)
+
+
+def k2_key_scores_packed(packed, w, bias, grid, H, S, D, bits, out=None):
+    """Fused per-channel key scores ``(H, S)`` from **bit-packed** codes.
+
+    ``packed`` is the flat byte array produced by
+    ``per_channel_kv._pack_indices`` (i.e. ``CompressedPerChannelKV.indices``
+    when ``packed=True``) -- half the KV-cache bytes of the unpacked path at
+    4-bit. Decode is at parity with :func:`k2_key_scores` (K2 is latency-bound,
+    so fewer bytes does not mean faster), so packing buys storage, not speed.
+    ``bits=4`` uses the fast LUT kernel (requires ``D % 64 == 0``); ``bits`` in
+    ``{2, 3}`` (or odd ``D``) use the general per-bit kernel. Arguments and the
+    return value match :func:`k2_key_scores`.
+    """
+    L = int(grid.shape[0])
+    if L > K2_MAX_LEVELS:
+        raise ValueError(f"grid has {L} levels; kernel caps at {K2_MAX_LEVELS}")
+    if bits not in (2, 3, 4):
+        raise ValueError(f"bits must be 2, 3, or 4, got {bits}")
+    if w.shape != (H, D):
+        raise ValueError(f"w must be (H,D)=({H},{D}), got {tuple(w.shape)}")
+    if bias.shape != (H,):
+        raise ValueError(f"bias must be (H,)=({H},), got {tuple(bias.shape)}")
+
+    if not (_HAS_CUPY and isinstance(packed, cp.ndarray)):
+        codes = _unpack_ref(packed, H, S, D, bits)
+        return _reference(codes, np.asarray(w), np.asarray(bias), np.asarray(grid))
+
+    packed = cp.ascontiguousarray(packed, dtype=cp.uint8)
+    w = cp.ascontiguousarray(w, dtype=cp.float32)
+    bias = cp.ascontiguousarray(bias, dtype=cp.float32)
+    grid = cp.ascontiguousarray(grid, dtype=cp.float32)
+    if out is None:
+        out = cp.empty((H, S), dtype=cp.float32)
+    tpb = 256
+    warps_per_block = tpb // 32
+    grid_x = (H * S + warps_per_block - 1) // warps_per_block
+    if bits == 4 and D % 64 == 0:
+        _get_kernel("k2_key_scores_packed4", _KERNEL_SRC_PACKED4)(
+            (grid_x,),
+            (tpb,),
+            (
+                packed,
+                _get_code_lut(),
+                w,
+                bias,
+                grid,
+                out,
+                np.int32(H),
+                np.int32(S),
+                np.int32(D),
+                np.int32(L),
+            ),
+        )
+    else:
+        _get_kernel("k2_key_scores_packed", _KERNEL_SRC_PACKED)(
+            (grid_x,),
+            (tpb,),
+            (
+                packed,
+                w,
+                bias,
+                grid,
+                out,
+                np.int32(H),
+                np.int32(S),
+                np.int32(D),
+                np.int32(L),
+                np.int32(bits),
+            ),
+        )
     return out


### PR DESCRIPTION
Volta-native fused KV-decode kernels for the GV100 (`sm_70`), extending the existing CuPy/NVRTC kernel layer — **no CUDA fork, no tensor cores** (K2 is the memory-bandwidth track; a W4A16 GEMM would be a separate K1 track). New module `turboquant_pro/volta_kernels.py` + dispatch from `kv_fused_pck`. Everything is exact to fp32 vs the NumPy references and validated on a real GV100.

## What it does
Per-channel asym-NF4 keys enter attention only through `q·k`, and PolarQuant values only through a weighted code sum, so the whole cold-block decode is computed **directly from the codes** — no `(H,S,D)` fp32 intermediate is ever materialized (the cupy `einsum(grid[codes])` reference does materialize it).

## Kernels (lazy-compiled via NVRTC at `compute_70`; NumPy fallback when CuPy absent)
- **`k2_key_scores`** — fused per-channel key score. Tuned kernel `vec4+ns4` (uint32 loads + 4 `s`-rows/warp for memory-level parallelism) reaches ~55–63% of HBM2 peak, **1.6–1.9× over the scalar version** and **~15–30× over decompress-then-attend**. Scalar kernel kept as the odd-`D` fallback.
- **`k2_key_scores_packed`** — reads the container's `packed=True` bytes (half the KV-cache storage), `vec+ns4` + a format-decode LUT. *Honest finding: packing is a **storage** win, not a decode speedup* — a D=128 packed row is 64 B (half a transaction), so it can't go bandwidth-bound; near-parity decode.
- **`value_accum`** — PolarQuant value accumulation (the transpose of the key score), **12–16× over the cupy einsum**.
- **`apply_outlier_csr`** — on-GPU dense-and-sparse key outlier correction (replaces a NumPy scatter).

## Integration
`kv_fused_pck.pck_key_scores` / `pck_cold_partials` dispatch to these kernels when `xp` is CuPy, else the einsum reference (NumPy path unchanged).

## Tests (`tests/test_volta_k2.py`, 12)
CPU fallbacks + format-integration run in CI; CuPy exactness for every kernel, the full `cold_partials` composition, and the **dispatched `pck_cold_partials` (keys with 2% outliers) vs the NumPy reference** skip without CuPy (mirroring the torch-optional tests). All pass on a GV100. Lint clean (ruff + black).

## Measured (uncontended Quadro GV100, ~870 GB/s peak, fp32-exact)
| kernel (S=8192) | fused | baseline | speedup |
|---|---|---|---|
| `k2_key_scores` | 0.064 ms | 1.54 ms (decompress+attend) | ~24× |
| `value_accum` | 0.093 ms | 1.46 ms (einsum) | ~16× |

Design notes, benchmarks, and the negative results (packing ≠ speedup; `gridLUT` occupancy regression; `ns8` no gain) are in `docs/notes/volta_k2_kv_decode.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)