### PR TITLE
P1 milestone 1: torch backend — instrument boundary + native torch decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## Unreleased
 
 ### Added
+- **Torch backend, milestone 1** (P1 of `docs/DESIGN_hardware_and_plugins.md`):
+  `turboquant_pro.backend` with `to_numpy` — the boundary adapter that lets
+  every instrument (rank certificate, (A2) probe) accept torch tensors from
+  **any device** (CUDA/ROCm/MPS/XPU) and CuPy arrays, with identical numbers
+  to NumPy input — and `torch_decode`, the decompress-then-attend reference
+  executed natively in torch on any device (every key format supported via
+  the cache's public getters; matches `fused_decode` to float tolerance).
+  Torch stays an optional, lazily-imported dependency. Device-parametrized
+  tests activate automatically on CUDA/MPS hosts. Remaining for P1 per the
+  design doc: the NRP batch-Job suite run on A100, and MPS/ROCm numbers.
 - **Quantizer plugin protocol + registry + conformance kit** (P0 of
   `docs/DESIGN_hardware_and_plugins.md`): `turboquant_pro.plugins` defines the
   minimal `Quantizer` protocol (compress/decompress — enough for every

--- a/tests/test_torch_backend.py
+++ b/tests/test_torch_backend.py
@@ -1,0 +1,144 @@
+"""
+Tests for the torch backend milestone of P1 (docs/DESIGN_hardware_and_plugins.md
+section 4.1): instruments accept torch tensors from any device via the
+to_numpy boundary, and torch_decode is the decompress-then-attend reference
+running natively on any torch device.
+
+Usage:
+    pytest tests/test_torch_backend.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from turboquant_pro.a2_probe import tangential_fraction
+from turboquant_pro.backend import is_torch_tensor, to_numpy
+from turboquant_pro.rank_certificate import certify, measure_kappa, mu_hat
+
+torch = pytest.importorskip("torch")
+
+RNG = np.random.default_rng(11)
+H, D = 4, 64
+
+
+def _devices() -> list[str]:
+    devs = ["cpu"]
+    if torch.cuda.is_available():
+        devs.append("cuda")
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        devs.append("mps")
+    return devs
+
+
+class TestToNumpy:
+    def test_numpy_passthrough(self) -> None:
+        x = RNG.standard_normal(5)
+        assert to_numpy(x) is not None and np.shares_memory(to_numpy(x), x)
+
+    def test_list_input(self) -> None:
+        assert to_numpy([1.0, 2.0]).shape == (2,)
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_torch_any_device(self, device) -> None:
+        t = torch.randn(3, 4, device=device)
+        out = to_numpy(t)
+        assert isinstance(out, np.ndarray) and out.shape == (3, 4)
+        assert np.allclose(out, t.detach().cpu().numpy())
+
+    def test_is_torch_tensor(self) -> None:
+        assert is_torch_tensor(torch.zeros(1))
+        assert not is_torch_tensor(np.zeros(1))
+
+
+class TestInstrumentsAcceptTorch:
+    """The exit criterion's instrument half: identical numbers from torch
+    inputs on every available device."""
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_certificate_matches_numpy(self, device) -> None:
+        exact = np.abs(RNG.standard_normal(4000)) + 0.1
+        approx = exact * np.exp(RNG.normal(0, 0.05, exact.shape))
+        want = certify(exact, approx)
+        got = certify(
+            torch.as_tensor(exact, device=device),
+            torch.as_tensor(approx, device=device),
+        )
+        assert got.kappa == want.kappa
+        assert got.tau_floor == want.tau_floor
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_kappa_mu_match(self, device) -> None:
+        exact = np.abs(RNG.standard_normal(2000)) + 0.1
+        approx = exact * 1.05
+        te = torch.as_tensor(exact, device=device)
+        ta = torch.as_tensor(approx, device=device)
+        assert measure_kappa(te, ta) == measure_kappa(exact, approx)
+        assert mu_hat(te, 1.2) == mu_hat(exact, 1.2)
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_tangential_fraction_matches(self, device) -> None:
+        x = RNG.standard_normal(64)
+        y = x + 0.01 * RNG.standard_normal(64)
+        want = tangential_fraction(x, y)
+        got = tangential_fraction(
+            torch.as_tensor(x, device=device), torch.as_tensor(y, device=device)
+        )
+        assert got == pytest.approx(want, abs=1e-12)
+
+
+class TestTorchDecode:
+    """The exit criterion's decode half: decompress-then-attend natively in
+    torch matches the cache's own fused decode."""
+
+    def _cache(self):
+        from turboquant_pro.core import TurboQuantKVCache
+
+        cache = TurboQuantKVCache(
+            head_dim=D,
+            n_heads=H,
+            bits=4,
+            use_gpu=False,
+            seed=0,
+            per_channel_keys=True,
+            key_nf4_asym=True,
+            key_outlier_frac=0.02,
+            hot_window=16,
+        )
+        off = RNG.uniform(-4, 4, size=(H, D)).astype(np.float32)
+        for _ in range(60):
+            cache.append(
+                (off + RNG.standard_normal((H, D))).astype(np.float32),
+                RNG.standard_normal((H, D)).astype(np.float32),
+            )
+        return cache
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_matches_fused_decode(self, device) -> None:
+        from turboquant_pro.backend import torch_decode
+
+        cache = self._cache()
+        q = RNG.standard_normal((H, D)).astype(np.float32)
+        want = np.asarray(cache.fused_decode(q))
+        got = torch_decode(cache, q, device=device)
+        assert str(got.device).startswith(device)
+        assert np.allclose(to_numpy(got), want, atol=5e-5), float(
+            np.abs(to_numpy(got) - want).max()
+        )
+
+    def test_device_follows_query_tensor(self) -> None:
+        from turboquant_pro.backend import torch_decode
+
+        cache = self._cache()
+        q = torch.randn(H, D)
+        out = torch_decode(cache, q)
+        assert out.device == q.device
+
+    def test_empty_cache_raises(self) -> None:
+        from turboquant_pro.backend import torch_decode
+        from turboquant_pro.core import TurboQuantKVCache
+
+        cache = TurboQuantKVCache(head_dim=D, n_heads=H, use_gpu=False)
+        with pytest.raises(RuntimeError, match="empty"):
+            torch_decode(cache, np.zeros((H, D), dtype=np.float32))

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -35,6 +35,7 @@ from .ans_codec import ANSCodec
 from .auto_compress import AutoCompressResult, auto_compress
 from .autoconfig import AutoConfig
 from .autotune import run_autotune
+from .backend import to_numpy, torch_decode
 from .behavioral_agreement import (
     BehavioralReport,
     FlipResult,
@@ -139,6 +140,8 @@ __all__ = [
     "noise_floor",
     "NoiseFloor",
     "CompressedKV",
+    "to_numpy",
+    "torch_decode",
     "CompressedPerChannelKV",
     "PerChannelKV",
     "PluginSpec",

--- a/turboquant_pro/a2_probe.py
+++ b/turboquant_pro/a2_probe.py
@@ -55,6 +55,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .backend import to_numpy
+
 __all__ = [
     "tangential_fraction",
     "tangential_fractions",
@@ -78,8 +80,8 @@ def tangential_fraction(x: np.ndarray, y: np.ndarray) -> float:
     values near 0 mean the pair differs mostly in norm (angular quantization
     is blind to it). Returns NaN for coincident vectors.
     """
-    x = np.asarray(x, dtype=np.float64).ravel()
-    y = np.asarray(y, dtype=np.float64).ravel()
+    x = np.asarray(to_numpy(x), dtype=np.float64).ravel()
+    y = np.asarray(to_numpy(y), dtype=np.float64).ravel()
     d2 = float(((x - y) ** 2).sum())
     if d2 <= 0.0:
         return float("nan")
@@ -94,7 +96,7 @@ def tangential_fractions(
     seed: int = 0,
 ) -> np.ndarray:
     """Tangential fractions over sampled row pairs of ``batch``."""
-    batch = np.asarray(batch, dtype=np.float64)
+    batch = np.asarray(to_numpy(batch), dtype=np.float64)
     n = batch.shape[0]
     if n < 2:
         return np.empty(0)
@@ -296,7 +298,7 @@ def probe_quotient(
         n_queries: Queries sampled from the batch when ``queries`` is None.
         seed: Determinism seed for rotation/query sampling.
     """
-    batch = np.asarray(batch, dtype=np.float64)
+    batch = np.asarray(to_numpy(batch), dtype=np.float64)
     if batch.ndim != 2 or batch.shape[0] < 4:
         raise ValueError("batch must be (n, d) with n >= 4")
     rng = np.random.default_rng(seed)
@@ -305,7 +307,7 @@ def probe_quotient(
             batch.shape[0], size=min(n_queries, batch.shape[0]), replace=False
         )
         queries = batch[take]
-    queries = np.asarray(queries, dtype=np.float64)
+    queries = np.asarray(to_numpy(queries), dtype=np.float64)
 
     exact = _consumer_scores(batch, queries, consumer)
     polar = _consumer_scores(_polar_proxy(batch, bits, rng), queries, consumer)

--- a/turboquant_pro/backend.py
+++ b/turboquant_pro/backend.py
@@ -1,0 +1,101 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""Array-backend helpers (P1 of ``docs/DESIGN_hardware_and_plugins.md``).
+
+Torch is the portability plane: one optional dependency covers CUDA, ROCm,
+Apple MPS, and Intel XPU. Two roles here:
+
+1. **Boundary conversion** (:func:`to_numpy`) — every instrument (rank
+   certificate, (A2) probe) accepts torch or CuPy arrays from *any* device.
+   Instruments are calibration-time tools; their math stays NumPy on CPU,
+   but a user holding device tensors should never have to know that.
+2. **Native-torch reference decode** (:func:`torch_decode`) — the
+   decompress-then-attend path executed on any torch device. This is the
+   no-kernel-work portability story: the KV cache's decode runs on ROCm/MPS
+   exactly as on CUDA, numerically matching the NumPy reference.
+
+The fused compute-on-codes kernels remain CuPy/CUDA (and, per the design
+doc, a future Triton port); this module is deliberately dependency-light —
+torch is imported lazily and only when torch objects actually appear.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "is_torch_tensor",
+    "is_cupy_array",
+    "to_numpy",
+    "torch_decode",
+]
+
+
+def is_torch_tensor(x) -> bool:
+    """True for ``torch.Tensor`` without importing torch."""
+    mod = type(x).__module__
+    return mod == "torch" or mod.startswith("torch.")
+
+
+def is_cupy_array(x) -> bool:
+    """True for ``cupy.ndarray`` without importing cupy."""
+    return type(x).__module__.startswith("cupy")
+
+
+def to_numpy(x) -> np.ndarray:
+    """Convert torch (any device), CuPy, or array-like input to NumPy.
+
+    The boundary adapter for calibration-time instruments: torch tensors are
+    detached and moved off-device; CuPy arrays are downloaded; everything
+    else goes through ``np.asarray`` unchanged.
+    """
+    if is_torch_tensor(x):
+        return x.detach().cpu().numpy()
+    if is_cupy_array(x):
+        import cupy as cp
+
+        return cp.asnumpy(x)
+    return np.asarray(x)
+
+
+def torch_decode(cache, query, *, device=None, dtype=None):
+    """One decode-step attention output over a ``TurboQuantKVCache``, computed
+    natively in torch on ``device`` (CUDA, ROCm, MPS, XPU, or CPU).
+
+    Decompress-then-attend: keys/values are reconstructed through the cache's
+    public getters (so every key format, including nuq, is supported) and the
+    attention math runs on-device. Numerically matches the NumPy reference
+    (and hence ``cache.fused_decode``) to float tolerance.
+
+    Args:
+        cache: A ``TurboQuantKVCache`` with at least one token stored.
+        query: ``(n_heads, head_dim)`` array or tensor.
+        device: torch device (default: ``query``'s device if it is a tensor,
+            else torch's default).
+        dtype: computation dtype (default ``torch.float32``).
+
+    Returns:
+        ``torch.Tensor`` of shape ``(n_heads, head_dim)`` on ``device``.
+    """
+    import torch
+
+    if cache.length == 0:
+        raise RuntimeError("cache is empty")
+    if device is None and is_torch_tensor(query):
+        device = query.device
+    dtype = dtype or torch.float32
+
+    q = torch.as_tensor(to_numpy(query), dtype=dtype, device=device).reshape(
+        cache.n_heads, cache.head_dim
+    )
+    k = torch.as_tensor(
+        to_numpy(cache.get_keys(0, cache.length))[0], dtype=dtype, device=device
+    )
+    v = torch.as_tensor(
+        to_numpy(cache.get_values(0, cache.length))[0], dtype=dtype, device=device
+    )
+    scores = torch.einsum("hd,hsd->hs", q, k) / float(np.sqrt(cache.head_dim))
+    p = torch.softmax(scores, dim=-1)
+    return torch.einsum("hs,hsd->hd", p, v)

--- a/turboquant_pro/rank_certificate.py
+++ b/turboquant_pro/rank_certificate.py
@@ -51,6 +51,8 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
+from .backend import to_numpy
+
 __all__ = [
     "RankCertificate",
     "certify",
@@ -89,8 +91,8 @@ def measure_kappa(
     Returns:
         kappa >= 1, or NaN if fewer than 2 valid pairs.
     """
-    exact = np.asarray(exact, dtype=np.float64).ravel()
-    approx = np.asarray(approx, dtype=np.float64).ravel()
+    exact = np.asarray(to_numpy(exact), dtype=np.float64).ravel()
+    approx = np.asarray(to_numpy(approx), dtype=np.float64).ravel()
     ok = exact > 0
     if ok.sum() < 2:
         return float("nan")
@@ -119,7 +121,7 @@ def mu_hat(exact: np.ndarray, kappa: float) -> float:
     """
     if not np.isfinite(kappa):
         return float("nan") if np.isnan(kappa) else 1.0
-    d = np.sort(np.asarray(exact, dtype=np.float64).ravel())
+    d = np.sort(np.asarray(to_numpy(exact), dtype=np.float64).ravel())
     d = d[d > 0]
     p = len(d)
     if p < 2:
@@ -138,7 +140,7 @@ def mu_curve(exact: np.ndarray, kappas: np.ndarray) -> np.ndarray:
     The steepness of this curve near kappa = 1 is a proxy for intrinsic
     dimension (concentrated distances = high-d regime).
     """
-    return np.array([mu_hat(exact, float(k)) for k in np.asarray(kappas)])
+    return np.array([mu_hat(exact, float(k)) for k in np.asarray(to_numpy(kappas))])
 
 
 def max_certifiable_kappa(
@@ -240,7 +242,7 @@ def certify(
         approx: 1-D compressed-domain distances over the same pairs.
         lo, hi: Robust-kappa percentiles.
     """
-    exact = np.asarray(exact, dtype=np.float64).ravel()
+    exact = np.asarray(to_numpy(exact), dtype=np.float64).ravel()
     n_pairs = int((exact > 0).sum())
     kappa = measure_kappa(exact, approx, lo=lo, hi=hi)
     mu = mu_hat(exact, kappa)
@@ -269,7 +271,7 @@ def pairwise_distances(
 
     Metrics: ``"cosine"`` (1 - cosine similarity) or ``"l2"`` (Euclidean).
     """
-    x = np.asarray(x, dtype=np.float64)
+    x = np.asarray(to_numpy(x), dtype=np.float64)
     if metric == "cosine":
         norms = np.maximum(np.linalg.norm(x, axis=1, keepdims=True), 1e-30)
         u = x / norms
@@ -305,8 +307,8 @@ def certificate_from_embeddings(
         metric: "cosine" or "l2" -- match the index's ranking metric.
         seed: Anchor-sampling seed.
     """
-    original = np.asarray(original)
-    reconstructed = np.asarray(reconstructed)
+    original = np.asarray(to_numpy(original))
+    reconstructed = np.asarray(to_numpy(reconstructed))
     if original.shape != reconstructed.shape:
         raise ValueError(f"shape mismatch: {original.shape} vs {reconstructed.shape}")
     n = original.shape[0]


### PR DESCRIPTION
First slice of P1 (`docs/DESIGN_hardware_and_plugins.md` §4.1 — torch as the portability plane).

- **`turboquant_pro.backend.to_numpy`** — boundary adapter: the rank certificate and (A2) probe now accept torch tensors from **any device** (CUDA/ROCm/MPS/XPU) and CuPy arrays, with numbers identical to NumPy input. Instruments stay NumPy/CPU inside — they're calibration-time tools; the caller never has to know.
- **`turboquant_pro.backend.torch_decode`** — decompress-then-attend executed natively in torch on any device, via the cache's public getters (every key format, including nuq). Matches `fused_decode` to 5e-5. This is the no-kernel-work KV-decode portability story.
- Torch remains optional and lazily imported. Entry-point wrapping in the instruments is pure widening — NumPy callers unchanged.

**Validation**: 10 device-parametrized tests (CUDA/MPS legs auto-activate on capable hosts); full suite 622 passed on the freshly merged master (M4 + K2 + P0 + rope_aware_k all together); ruff + black clean.

**Remaining for P1** (follow-ups): the NRP batch-Job suite run (A100/L40S) for the on-device legs, and MPS numbers from an Apple host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)