### PR TITLE
P1 slice 2: torch_xp shim — reference einsum paths on any torch device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,13 @@
   tolerance). It is a correctness/portability reference, *not* a zero-copy or
   fused on-device dequant. Torch stays an optional, lazily-imported dependency
   (`pip install turboquant-pro[torch]`). Device-parametrized
-  tests activate automatically on CUDA/MPS hosts. Remaining for P1 per the
-  design doc: the NRP batch-Job suite run on A100, and MPS/ROCm numbers.
+  tests activate automatically on CUDA/MPS hosts. P1 slice 2: `backend.torch_xp` — a NumPy-signature shim (amax/keepdims
+  naming, uint8-code promotion for torch's mask-indexing semantics) that
+  runs the `kv_fused` / `kv_fused_pck` **reference einsum paths on any
+  torch device** via the existing `xp=` seam, matching NumPy to 5e-5;
+  suite-leg run green on NRP L40S (torch-CUDA legs all pass; issue #123
+  filed for two pre-existing GPU-present/cupy-absent failures). Remaining
+  for P1: MPS numbers (needs an Apple host); A100 leg deferred.
 - **Quantizer plugin protocol + registry + conformance kit** (P0 of
   `docs/DESIGN_hardware_and_plugins.md`): `turboquant_pro.plugins` defines the
   minimal `Quantizer` protocol (compress/decompress — enough for every

--- a/tests/test_torch_backend.py
+++ b/tests/test_torch_backend.py
@@ -142,3 +142,79 @@ class TestTorchDecode:
         cache = TurboQuantKVCache(head_dim=D, n_heads=H, use_gpu=False)
         with pytest.raises(RuntimeError, match="empty"):
             torch_decode(cache, np.zeros((H, D), dtype=np.float32))
+
+
+class TestTorchXPReferencePaths:
+    """P1 slice 2: the kv_fused reference einsums run with xp=torch_xp on any
+    device and match the NumPy reference."""
+
+    def _polar(self):
+        from turboquant_pro.core import TurboQuantKV
+
+        tq = TurboQuantKV(head_dim=D, n_heads=H, bits=4, use_gpu=False, seed=0)
+        S = 48
+        k = RNG.standard_normal((H, S, D)).astype(np.float32)
+        v = RNG.standard_normal((H, S, D)).astype(np.float32)
+        codes = {}
+        norms = {}
+        for name, x in (("k", k), ("v", v)):
+            n = np.linalg.norm(x, axis=-1)
+            unit = x / np.maximum(n[..., None], 1e-30)
+            rot = np.einsum("hsd,de->hse", unit, np.asarray(tq._Pi_T, dtype=np.float32))
+            codes[name] = np.searchsorted(tq.boundaries, rot).astype(np.uint8)
+            norms[name] = n.astype(np.float32)
+        return tq, codes, norms
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_fused_decode_attention_matches(self, device) -> None:
+        from turboquant_pro.backend import torch_xp
+        from turboquant_pro.kv_fused import fused_decode_attention
+
+        tq, codes, norms = self._polar()
+        q = RNG.standard_normal((H, D)).astype(np.float32)
+        want = fused_decode_attention(
+            q, codes["k"], codes["v"], norms["k"], norms["v"], tq, xp=np
+        )
+        dev = torch.device(device)
+        got = fused_decode_attention(
+            torch.as_tensor(q, device=dev),
+            torch.as_tensor(codes["k"], device=dev),
+            torch.as_tensor(codes["v"], device=dev),
+            torch.as_tensor(norms["k"], device=dev),
+            torch.as_tensor(norms["v"], device=dev),
+            tq,
+            xp=torch_xp,
+        )
+        assert np.allclose(to_numpy(got), want, atol=5e-5)
+
+    @pytest.mark.parametrize("device", _devices())
+    def test_full_fused_decode_with_hot_window(self, device) -> None:
+        from turboquant_pro.backend import torch_xp
+        from turboquant_pro.kv_fused import fused_decode
+
+        tq, codes, norms = self._polar()
+        q = RNG.standard_normal((H, D)).astype(np.float32)
+        hot_k = RNG.standard_normal((H, 8, D)).astype(np.float32)
+        hot_v = RNG.standard_normal((H, 8, D)).astype(np.float32)
+        want = fused_decode(
+            q, hot_k, hot_v, codes["k"], codes["v"], norms["k"], norms["v"], tq, xp=np
+        )
+        dev = torch.device(device)
+        args = [q, hot_k, hot_v, codes["k"], codes["v"], norms["k"], norms["v"]]
+        targs = [torch.as_tensor(a, device=dev) for a in args]
+        got = fused_decode(*targs, tq, xp=torch_xp)
+        assert np.allclose(to_numpy(got), want, atol=5e-5)
+
+    def test_pck_reference_scores_match(self) -> None:
+        from turboquant_pro.backend import torch_xp
+        from turboquant_pro.kv_fused_pck import pck_key_scores
+        from turboquant_pro.per_channel_kv import PerChannelKV
+
+        quant = PerChannelKV(head_dim=D, n_heads=H, nf4_asym=True, outlier_frac=0.02)
+        off = RNG.uniform(-4, 4, size=(1, H, 1, D))
+        x = (off + RNG.standard_normal((1, H, 48, D))).astype(np.float32)
+        c = quant.compress(x)
+        q = RNG.standard_normal((H, D)).astype(np.float32)
+        want = pck_key_scores(q, quant, c, xp=np)
+        got = pck_key_scores(torch.as_tensor(q), quant, c, xp=torch_xp)
+        assert np.allclose(to_numpy(got), want, atol=5e-5)

--- a/turboquant_pro/backend.py
+++ b/turboquant_pro/backend.py
@@ -30,6 +30,7 @@ __all__ = [
     "is_cupy_array",
     "to_numpy",
     "torch_decode",
+    "torch_xp",
 ]
 
 
@@ -103,3 +104,45 @@ def torch_decode(cache, query, *, device=None, dtype=None):
     scores = torch.einsum("hd,hsd->hs", q, k) / float(np.sqrt(cache.head_dim))
     p = torch.softmax(scores, dim=-1)
     return torch.einsum("hs,hsd->hd", p, v)
+
+
+class _TorchXP:
+    """NumPy-signature shim over torch for the ``xp=`` reference paths
+    (``kv_fused``, ``kv_fused_pck``): the three real incompatibilities are
+    ``max``-returns-namedtuple (use :meth:`amax`), ``keepdims`` naming, and
+    uint8 fancy-indexing (torch treats it as a mask — integer arrays without
+    an explicit dtype are promoted to int64 code indices). Everything else
+    delegates to torch directly. Use as ``xp=torch_xp``; pair with
+    ``device=`` on the input tensors — ops inherit their device.
+    """
+
+    def __getattr__(self, name):
+        import torch
+
+        return getattr(torch, name)
+
+    def asarray(self, x, dtype=None):
+        import torch
+
+        t = torch.as_tensor(x) if not is_torch_tensor(x) else x
+        if dtype is not None:
+            return t.to(dtype)
+        if not t.is_floating_point() and t.dtype != torch.int64:
+            return t.long()  # code indices: uint8 indexing would be a mask
+        return t
+
+    def ascontiguousarray(self, x):
+        return self.asarray(x).contiguous()
+
+    def amax(self, x, axis=None, keepdims=False):
+        import torch
+
+        return torch.amax(x, dim=axis, keepdim=keepdims)
+
+    def concatenate(self, xs, axis=0):
+        import torch
+
+        return torch.cat(list(xs), dim=axis)
+
+
+torch_xp = _TorchXP()

--- a/turboquant_pro/kv_fused.py
+++ b/turboquant_pro/kv_fused.py
@@ -34,13 +34,14 @@ def _rot_matrices(tq, xp):
 
 
 def _softmax(x, xp):
-    x = x - xp.max(x, axis=-1, keepdims=True)
+    x = x - xp.amax(x, axis=-1, keepdims=True)
     e = xp.exp(x)
     return e / xp.sum(e, axis=-1, keepdims=True)
 
 
 def fused_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
     """One decode-step attention output computed in code space (the fused path)."""
+    kcodes, vcodes = xp.asarray(kcodes), xp.asarray(vcodes)
     d = q.shape[-1]
     pit, pi, cent = _rot_matrices(tq, xp)
     q_rot = xp.asarray(q, dtype=xp.float32) @ pit
@@ -57,6 +58,7 @@ def fused_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
 
 def dequant_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
     """Reference: reconstruct K/V to fp32, then standard attention (same math)."""
+    kcodes, vcodes = xp.asarray(kcodes), xp.asarray(vcodes)
     d = q.shape[-1]
     _, pi, cent = _rot_matrices(tq, xp)
     k = xp.asarray(norm_k, dtype=xp.float32)[..., None] * (cent[kcodes] @ pi)
@@ -70,13 +72,14 @@ def dequant_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
 
 def _cold_partials(q, kcodes, vcodes, norm_k, norm_v, tq, scale, xp):
     """Unnormalized (m, l, acc) for cold (coded) keys/values, in real space."""
+    kcodes, vcodes = xp.asarray(kcodes), xp.asarray(vcodes)
     pit, pi, cent = _rot_matrices(tq, xp)
     q_rot = xp.asarray(q, dtype=xp.float32) @ pit
     sc = (
         xp.asarray(norm_k, dtype=xp.float32)
         * xp.einsum("hsd,hd->hs", cent[kcodes], q_rot)
     ) * scale
-    m = sc.max(axis=1)
+    m = xp.amax(sc, axis=1)
     e = xp.exp(sc - m[:, None])
     lsum = e.sum(axis=1)
     acc_code = xp.einsum(
@@ -95,7 +98,7 @@ def _hot_partials(q, hot_k, hot_v, scale, xp):
         )
         * scale
     )
-    m = sc.max(axis=1)
+    m = xp.amax(sc, axis=1)
     e = xp.exp(sc - m[:, None])
     return (
         m,

--- a/turboquant_pro/kv_fused_pck.py
+++ b/turboquant_pro/kv_fused_pck.py
@@ -208,7 +208,7 @@ class PreparedPCKBlock:
         (``xp=cupy``), the reference einsum on CPU. Merges with hot/other-page
         partials via :func:`turboquant_pro.kv_fused.merge_partials`."""
         xp = self.xp
-        if xp is not np:
+        if _is_cupy(xp):
             from .kv_kernel import pck_block_partials_cuda
 
             return pck_block_partials_cuda(q, self, tq, scale=scale)
@@ -216,7 +216,7 @@ class PreparedPCKBlock:
 
         _, pi, cent = _rot_matrices(tq, xp)
         sc = self.key_scores(q) * scale
-        m = sc.max(axis=1)
+        m = xp.amax(sc, axis=1)
         e = xp.exp(sc - m[:, None])
         acc_code = xp.einsum("hs,hsd->hd", e * self.norm_v, cent[self.vcodes])
         return m, e.sum(axis=1), acc_code @ pi
@@ -275,7 +275,7 @@ def pck_cold_partials(q, q_kv, kc, vcodes, norm_v, tq, scale, xp=np):
 
     _, pi, cent = _rot_matrices(tq, xp)
     sc = pck_key_scores(q, q_kv, kc, xp) * scale
-    m = sc.max(axis=1)
+    m = xp.amax(sc, axis=1)
     e = xp.exp(sc - m[:, None])
     lsum = e.sum(axis=1)
     wv = e * xp.asarray(norm_v, dtype=xp.float32)


### PR DESCRIPTION
Completes the implementable remainder of P1 (A100 leg deferred per direction; MPS awaits an Apple host). `backend.torch_xp` absorbs torch's three NumPy incompatibilities (max-namedtuple → `xp.amax`, keepdim naming, uint8 mask-indexing → int64 code promotion) so the `kv_fused`/`kv_fused_pck` reference paths run on any torch device through the existing `xp=` seam, matching NumPy to 5e-5. Also fixes `PreparedPCKBlock.partials` kernel gating to `_is_cupy(xp)` (latently wrong for any third namespace). 3 new device-parametrized tests; full suite green; NRP L40S suite-leg result recorded in CHANGELOG (torch-CUDA legs pass; issue #123 tracks the two pre-existing GPU/cupy-absent failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)