### PR TITLE
P2 milestone 1: tqp-bnb plugin incubator (bitsandbytes NF4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 > install from `master` for the items below.
 
 ### Added
+- **`tqp-bnb` plugin incubator** (P2 milestone 1, `plugins/tqp-bnb/`):
+  the first external consumer of the P0 contract — bitsandbytes blockwise
+  NF4 (QLoRA semantics: per-block absmax over the fixed NF4 table) as a
+  separately-installable package registering via the
+  `turboquant_pro.plugins` entry point. NumPy reference implementation;
+  cross-check vs `bnb.functional` runs where bitsandbytes+CUDA exist.
+  Passes conformance with `affine: skip` — blockwise scales vary along
+  the token axis, so fused decode awaits the block-granular contract
+  extension (milestone 2, design doc §6).
 - **Torch backend, milestone 1** (P1 of `docs/DESIGN_hardware_and_plugins.md`):
   `turboquant_pro.backend` with `to_numpy` — the boundary adapter that lets
   every instrument (rank certificate, (A2) probe) accept torch tensors from

--- a/plugins/tqp-bnb/pyproject.toml
+++ b/plugins/tqp-bnb/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tqp-bnb"
+version = "0.1.0"
+description = "bitsandbytes-format quantizer plugins for turboquant-pro (P2 of DESIGN_hardware_and_plugins.md)"
+requires-python = ">=3.10"
+dependencies = ["numpy", "turboquant-pro>=1.7"]
+
+[project.optional-dependencies]
+bnb = ["bitsandbytes>=0.44", "torch"]
+
+[project.entry-points."turboquant_pro.plugins"]
+bnb_nf4 = "tqp_bnb.plugin:SPEC_NF4"

--- a/plugins/tqp-bnb/tests/test_bnb_nf4.py
+++ b/plugins/tqp-bnb/tests/test_bnb_nf4.py
@@ -1,0 +1,62 @@
+"""Conformance + semantics tests for the bnb_nf4 plugin (run in this
+package's own CI; needs only turboquant-pro + numpy)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from tqp_bnb.plugin import SPEC_NF4, BnbNF4Quantizer
+
+from turboquant_pro.plugin_conformance import assert_conformance
+from turboquant_pro.plugins import Quantizer, register
+
+RNG = np.random.default_rng(3)
+
+
+def test_conformance_kv_block():
+    q = BnbNF4Quantizer()
+    x = RNG.standard_normal((1, 4, 96, 64)).astype(np.float32)
+    report = assert_conformance(q, x, rel_err_max=0.30)
+    assert report.results["affine"].startswith("skip")
+    assert report.results["packed"].startswith("skip")
+
+
+def test_protocol_and_spec():
+    assert isinstance(BnbNF4Quantizer(), Quantizer)
+    with pytest.raises(ValueError, match="already registered"):
+        register(SPEC_NF4)  # only if a prior import registered it
+        register(SPEC_NF4)
+
+
+def test_blockwise_semantics_exact_table_values():
+    q = BnbNF4Quantizer(blocksize=8)
+    # values exactly on the scaled table reconstruct exactly
+    tab = np.asarray(
+        [q._table[i] for i in [0, 3, 7, 8, 12, 15, 1, 14]], dtype=np.float32
+    )
+    x = (tab * 2.5).reshape(1, 1, 1, 8)
+    got = q.decompress(q.compress(x))
+    assert np.allclose(got, x, atol=1e-6)
+
+
+def test_tail_padding_roundtrip():
+    q = BnbNF4Quantizer(blocksize=64)
+    x = RNG.standard_normal((1, 1, 1, 100)).astype(np.float32)  # not divisible
+    got = q.decompress(q.compress(x))
+    assert got.shape == x.shape and np.isfinite(got).all()
+
+
+def test_crosscheck_against_bitsandbytes():
+    bnb = pytest.importorskip("bitsandbytes")
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("bnb 4-bit needs CUDA")
+    x = RNG.standard_normal((256, 64)).astype(np.float32)
+    qt, state = bnb.functional.quantize_4bit(
+        torch.tensor(x, device="cuda"), blocksize=64, quant_type="nf4"
+    )
+    want = bnb.functional.dequantize_4bit(qt, state).cpu().numpy()
+    got = BnbNF4Quantizer(blocksize=64).decompress(
+        BnbNF4Quantizer(blocksize=64).compress(x)
+    )
+    assert np.allclose(got, want, atol=2e-3), float(np.abs(got - want).max())

--- a/plugins/tqp-bnb/tqp_bnb/__init__.py
+++ b/plugins/tqp-bnb/tqp_bnb/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import SPEC_NF4, BnbNF4Quantizer
+
+__all__ = ["SPEC_NF4", "BnbNF4Quantizer"]

--- a/plugins/tqp-bnb/tqp_bnb/plugin.py
+++ b/plugins/tqp-bnb/tqp_bnb/plugin.py
@@ -1,0 +1,92 @@
+# tqp-bnb: bitsandbytes-format plugins for turboquant-pro
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""bitsandbytes NF4 (QLoRA) as a turboquant-pro quantizer plugin.
+
+The first external consumer of the P0 plugin contract, living out of tree
+(installed separately; discovered via the ``turboquant_pro.plugins`` entry
+point). Implements bnb's blockwise NF4: flatten, split into ``blocksize``
+blocks, per-block absmax scale, nearest-entry lookup in the fixed 16-value
+NF4 table. A pure-NumPy implementation is the reference (the same table
+turboquant-pro ships); when bitsandbytes + torch are installed the tests
+cross-check dequantization against ``bnb.functional`` itself.
+
+Affine contract status: blockwise scales vary along the *token* axis, so the
+(H, D) per-channel form of ``grid_params`` cannot express them —
+``grid_params`` returns ``None`` and the format takes the documented
+decompress-then-attend degrade. The block-granular contract extension
+(weight ``(H, ceil(S/blocks), D)``, design doc §6) is milestone 2; when it
+lands, this plugin inherits the fused decode with no kernel work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from turboquant_pro.per_channel_kv import _NF4
+from turboquant_pro.plugins import TARGET_KV_KEY, TARGET_WEIGHT, PluginSpec
+
+
+@dataclass
+class BnbNF4Container:
+    codes: np.ndarray  # (n_blocks, blocksize) uint8, NF4 table indices
+    absmax: np.ndarray  # (n_blocks,) float32 per-block scale
+    shape: tuple
+    blocksize: int
+    n: int  # valid elements (tail block is zero-padded)
+
+
+class BnbNF4Quantizer:
+    """Blockwise NF4 (bitsandbytes/QLoRA semantics), NumPy reference."""
+
+    def __init__(self, blocksize: int = 64):
+        if blocksize <= 0:
+            raise ValueError("blocksize must be positive")
+        self.blocksize = blocksize
+        self._table = np.asarray(_NF4, dtype=np.float32)
+
+    def compress(self, x: np.ndarray) -> BnbNF4Container:
+        x = np.asarray(x, dtype=np.float32)
+        flat = x.ravel()
+        n = flat.size
+        pad = (-n) % self.blocksize
+        if pad:
+            flat = np.concatenate([flat, np.zeros(pad, dtype=np.float32)])
+        blocks = flat.reshape(-1, self.blocksize)
+        absmax = np.abs(blocks).max(axis=1).astype(np.float32)
+        scale = np.maximum(absmax, 1e-12)[:, None]
+        codes = np.abs(
+            blocks[..., None] / scale[..., None] - self._table
+        ).argmin(axis=-1)
+        return BnbNF4Container(
+            codes.astype(np.uint8), absmax, x.shape, self.blocksize, n
+        )
+
+    def decompress(self, c: BnbNF4Container) -> np.ndarray:
+        vals = self._table[c.codes] * np.maximum(c.absmax, 1e-12)[:, None]
+        return vals.ravel()[: c.n].reshape(c.shape).astype(np.float32)
+
+    def grid_params(self, c: BnbNF4Container):
+        # blockwise scales vary along the token axis: not expressible as the
+        # (H, D) per-channel affine form -- decompress-then-attend degrade
+        # until the block-granular contract extension (milestone 2).
+        return None
+
+    def native_dtype(self):
+        return None
+
+
+SPEC_NF4 = PluginSpec(
+    name="bnb_nf4",
+    factory=BnbNF4Quantizer,
+    targets=frozenset({TARGET_WEIGHT, TARGET_KV_KEY}),
+    tier="experimental",
+    description=(
+        "bitsandbytes blockwise NF4 (QLoRA): per-block absmax over the fixed "
+        "NF4 table; NumPy reference, bnb cross-checked when installed; "
+        "decompress-then-attend until the block-granular affine extension"
+    ),
+)


### PR DESCRIPTION
First external consumer of the P0 contract: `plugins/tqp-bnb/` — separately installable, registers `bnb_nf4` via the entry-point group. Blockwise NF4 with QLoRA semantics (NumPy reference; `bnb.functional` cross-check activates on bnb+CUDA hosts). Conformance green with an honest `affine: skip` — blockwise scales vary along the token axis, so fused decode awaits the block-granular contract extension (milestone 2, design doc §6). QLoRA interop demo + LLM.int8 adapter follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)