### PR TITLE
P2 milestone 2: block-granular affine contract; bnb_nf4 fused-eligible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 > install from `master` for the items below.
 
 ### Added
+- **Block-granular affine contract** (P2 milestone 2, design doc §6):
+  `grid_params` weight may now be token-block-granular `(H, S, D)` as
+  well as per-channel `(H, D)`; conformance broadcasts both. `bnb_nf4`
+  implements it — its conformance `affine` check now **passes** (block
+  absmax expanded per element reproduces `decompress` exactly), so the
+  bitsandbytes NF4 format is fused-decode-eligible; kernel-side compact
+  block weights are follow-up work.
 - **`tqp-bnb` plugin incubator** (P2 milestone 1, `plugins/tqp-bnb/`):
   the first external consumer of the P0 contract — bitsandbytes blockwise
   NF4 (QLoRA semantics: per-block absmax over the fixed NF4 table) as a

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -59,7 +59,10 @@ class MyQuantizer:
     def outlier_csr(self, c):   # (row_ptr, cols, deltas) token-major, or None
 ```
 
-Return `None` from `grid_params` for containers with no affine form (e.g.
+`weight` may be per-channel `(H, D)` or token-block-granular `(H, S, D)`
+(the design doc §6 extension — fold per-block scales by expanding them per
+element; `tqp_bnb.BnbNF4Quantizer.grid_params` is the reference). Return
+`None` from `grid_params` for containers with no affine form (e.g.
 learned per-channel tables) — that is the documented graceful degrade to
 decompress-then-attend, not an error. blockwise-scaled formats (bitsandbytes
 NF4, block-16 FP4): fold the block scale into `weight`; GPTQ/AWQ-style

--- a/plugins/tqp-bnb/tests/test_bnb_nf4.py
+++ b/plugins/tqp-bnb/tests/test_bnb_nf4.py
@@ -17,8 +17,26 @@ def test_conformance_kv_block():
     q = BnbNF4Quantizer()
     x = RNG.standard_normal((1, 4, 96, 64)).astype(np.float32)
     report = assert_conformance(q, x, rel_err_max=0.30)
-    assert report.results["affine"].startswith("skip")
+    assert report.results["affine"].startswith("pass"), report
     assert report.results["packed"].startswith("skip")
+
+
+def test_block_granular_affine_matches_decompress():
+    """Milestone 2: the (H, S, D) block-granular weight reproduces
+    decompress exactly -- the gate that makes fused decode inheritable."""
+    q = BnbNF4Quantizer(blocksize=64)
+    x = RNG.standard_normal((1, 4, 96, 64)).astype(np.float32)
+    c = q.compress(x)
+    mu, w, grid = q.grid_params(c)
+    assert mu.shape == (4, 64) and w.shape == (4, 96, 64)
+    dense = mu[:, None, :] + w * grid[q.codes(c)[0]]
+    assert np.allclose(dense[None], q.decompress(c), atol=1e-6)
+
+
+def test_non_kv_shape_degrades():
+    q = BnbNF4Quantizer()
+    c = q.compress(RNG.standard_normal((128, 64)).astype(np.float32))
+    assert q.grid_params(c) is None
 
 
 def test_protocol_and_spec():

--- a/plugins/tqp-bnb/tqp_bnb/plugin.py
+++ b/plugins/tqp-bnb/tqp_bnb/plugin.py
@@ -58,9 +58,9 @@ class BnbNF4Quantizer:
         blocks = flat.reshape(-1, self.blocksize)
         absmax = np.abs(blocks).max(axis=1).astype(np.float32)
         scale = np.maximum(absmax, 1e-12)[:, None]
-        codes = np.abs(
-            blocks[..., None] / scale[..., None] - self._table
-        ).argmin(axis=-1)
+        codes = np.abs(blocks[..., None] / scale[..., None] - self._table).argmin(
+            axis=-1
+        )
         return BnbNF4Container(
             codes.astype(np.uint8), absmax, x.shape, self.blocksize, n
         )
@@ -70,10 +70,23 @@ class BnbNF4Quantizer:
         return vals.ravel()[: c.n].reshape(c.shape).astype(np.float32)
 
     def grid_params(self, c: BnbNF4Container):
-        # blockwise scales vary along the token axis: not expressible as the
-        # (H, D) per-channel affine form -- decompress-then-attend degrade
-        # until the block-granular contract extension (milestone 2).
-        return None
+        """Block-granular affine form (contract extension, design doc §6):
+        ``mu`` is zeros ``(H, D)`` (NF4 is symmetric); ``weight`` is the
+        per-element block absmax expanded to ``(H, S, D)`` -- reference and
+        conformance broadcast it to ``(B, H, S, D)``. Requires the KV block
+        convention ``(1, H, S, D)``; other shapes degrade to ``None``."""
+        if len(c.shape) != 4 or c.shape[0] != 1:
+            return None
+        _, H, S, D = c.shape
+        w = np.repeat(np.maximum(c.absmax, 1e-12), self.blocksize)[: c.n].reshape(
+            H, S, D
+        )
+        return np.zeros((H, D), dtype=np.float32), w.astype(np.float32), self._table
+
+    def codes(self, c: BnbNF4Container) -> np.ndarray:
+        if len(c.shape) != 4:
+            raise NotImplementedError("codes() requires the (B,H,S,D) block form")
+        return c.codes.ravel()[: c.n].reshape(c.shape)
 
     def native_dtype(self):
         return None

--- a/turboquant_pro/plugin_conformance.py
+++ b/turboquant_pro/plugin_conformance.py
@@ -152,11 +152,15 @@ def run_conformance(
         try:
             mu, weight, grid = params
             grid = np.asarray(grid, dtype=np.float32)
-            dense = (
-                np.asarray(mu, dtype=np.float32)[None, :, None, :]
-                + np.asarray(weight, dtype=np.float32)[None, :, None, :]
-                * grid[np.asarray(codes)]
-            )
+
+            def _bhsd(a):
+                # the block-granular contract extension (design doc §6):
+                # per-channel params are (H, D); token-block-granular
+                # params are (H, S, D) — both broadcast to (B, H, S, D)
+                a = np.asarray(a, dtype=np.float32)
+                return a[None, :, None, :] if a.ndim == 2 else a[None]
+
+            dense = _bhsd(mu) + _bhsd(weight) * grid[np.asarray(codes)]
             csr = outlier_csr(quantizer, c)
             if csr is not None:
                 row_ptr, cols, deltas = csr


### PR DESCRIPTION
Ships the design doc §6 extension: `grid_params` weight may be token-block-granular `(H, S, D)` alongside per-channel `(H, D)`; conformance broadcasts both. `bnb_nf4` implements it as the reference — its affine check flips skip→**pass** (block absmax reproduces `decompress` exactly), making bitsandbytes NF4 fused-decode-eligible through the contract. Kernel-side compact block weights are follow-up. 26 plugin+registry tests pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)