### PR TITLE
P2: bnb_llm_int8 — LLM.int8 mixed decomposition through the contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 > install from `master` for the items below.
 
 ### Added
+- **`bnb_llm_int8` plugin** (P2): LLM.int8 mixed decomposition on the KV
+  block convention — per-channel int8 absmax dense part + fp16 outlier
+  *channels* (Dettmers-style emergent features) surfaced through the
+  contract's `outlier_csr` as dense per-token columns. Conformance:
+  affine **pass** and CSR **pass** — LLM.int8's decomposition is the
+  dense-sparse overlay at column granularity, so the format is fully
+  fused-decode-eligible with no kernel changes.
 - **Block-granular affine contract** (P2 milestone 2, design doc §6):
   `grid_params` weight may now be token-block-granular `(H, S, D)` as
   well as per-channel `(H, D)`; conformance broadcasts both. `bnb_nf4`

--- a/plugins/tqp-bnb/pyproject.toml
+++ b/plugins/tqp-bnb/pyproject.toml
@@ -14,3 +14,4 @@ bnb = ["bitsandbytes>=0.44", "torch"]
 
 [project.entry-points."turboquant_pro.plugins"]
 bnb_nf4 = "tqp_bnb.plugin:SPEC_NF4"
+bnb_llm_int8 = "tqp_bnb.plugin:SPEC_INT8"

--- a/plugins/tqp-bnb/tests/test_bnb_nf4.py
+++ b/plugins/tqp-bnb/tests/test_bnb_nf4.py
@@ -78,3 +78,47 @@ def test_crosscheck_against_bitsandbytes():
         BnbNF4Quantizer(blocksize=64).compress(x)
     )
     assert np.allclose(got, want, atol=2e-3), float(np.abs(got - want).max())
+
+
+# ------------------------------------------------------------------ #
+# LLM.int8 adapter                                                    #
+# ------------------------------------------------------------------ #
+
+
+def _outlier_block(H=4, S=48, D=64, n_out=3):
+    x = RNG.standard_normal((1, H, S, D)).astype(np.float32)
+    for h in range(H):
+        for d in RNG.choice(D, n_out, replace=False):
+            x[0, h, :, d] *= 12.0  # emergent-feature column
+    return x
+
+
+def test_int8_conformance_full_affine_and_csr():
+    from tqp_bnb.plugin import LLMInt8Quantizer
+
+    q = LLMInt8Quantizer()
+    report = assert_conformance(q, _outlier_block(), rel_err_max=0.30)
+    assert report.results["affine"].startswith("pass"), report
+    assert report.results["csr"] == "pass", report
+
+
+def test_int8_outlier_channels_fp16_exact():
+    from tqp_bnb.plugin import LLMInt8Quantizer
+
+    q = LLMInt8Quantizer()
+    x = _outlier_block()
+    c = q.compress(x)
+    got = q.decompress(c)
+    mask = c.outlier_mask  # (H, D)
+    for h, d in zip(*np.nonzero(mask)):
+        assert np.allclose(got[0, h, :, d], x[0, h, :, d].astype(np.float16), atol=1e-3)
+    assert mask.sum() >= 3
+
+
+def test_int8_no_outliers_csr_none():
+    from tqp_bnb.plugin import LLMInt8Quantizer
+
+    q = LLMInt8Quantizer(outlier_threshold=1e9)
+    c = q.compress(RNG.standard_normal((1, 2, 16, 32)).astype(np.float32))
+    assert q.outlier_csr(c) is None
+    assert not c.outlier_mask.any()

--- a/plugins/tqp-bnb/tqp_bnb/__init__.py
+++ b/plugins/tqp-bnb/tqp_bnb/__init__.py
@@ -1,3 +1,3 @@
-from .plugin import SPEC_NF4, BnbNF4Quantizer
+from .plugin import SPEC_INT8, SPEC_NF4, BnbNF4Quantizer, LLMInt8Quantizer
 
-__all__ = ["SPEC_NF4", "BnbNF4Quantizer"]
+__all__ = ["SPEC_INT8", "SPEC_NF4", "BnbNF4Quantizer", "LLMInt8Quantizer"]

--- a/plugins/tqp-bnb/tqp_bnb/plugin.py
+++ b/plugins/tqp-bnb/tqp_bnb/plugin.py
@@ -103,3 +103,109 @@ SPEC_NF4 = PluginSpec(
         "decompress-then-attend until the block-granular affine extension"
     ),
 )
+
+
+# ------------------------------------------------------------------ #
+# LLM.int8: vector-wise int8 + fp16 outlier channels                  #
+# ------------------------------------------------------------------ #
+
+
+@dataclass
+class LLMInt8Container:
+    codes: np.ndarray  # (1, H, S, D) uint8, value = int8_code + 127
+    scale: np.ndarray  # (H, D) float32 per-channel absmax / 127
+    outlier_mask: np.ndarray  # (H, D) bool -- channels kept fp16
+    outlier_vals: np.ndarray  # (n_outliers, S) float16, channel-major
+    shape: tuple
+
+
+_INT8_GRID = np.arange(-127, 128, dtype=np.float32)  # 255 levels
+
+
+class LLMInt8Quantizer:
+    """LLM.int8-style mixed decomposition on the KV block convention
+    ``(1, H, S, D)``: per-channel int8 absmax for the dense part, whole
+    channels whose peak magnitude exceeds ``outlier_threshold`` kept fp16
+    (Dettmers et al.'s emergent-feature columns). The outliers surface
+    through the contract's ``outlier_csr`` as dense per-token columns --
+    LLM.int8's decomposition IS the dense-sparse overlay at column
+    granularity, so the format is fully fused-decode-eligible."""
+
+    def __init__(self, outlier_threshold: float = 6.0):
+        self.outlier_threshold = float(outlier_threshold)
+
+    def compress(self, x: np.ndarray) -> LLMInt8Container:
+        x = np.asarray(x, dtype=np.float32)
+        if x.ndim != 4 or x.shape[0] != 1:
+            raise ValueError("LLMInt8Quantizer expects the (1, H, S, D) block form")
+        _, H, S, D = x.shape
+        peak = np.abs(x[0]).max(axis=1)  # (H, D)
+        mask = peak > self.outlier_threshold
+        scale = np.maximum(peak, 1e-12).astype(np.float32) / 127.0
+        codes = (np.clip(np.round(x[0] / scale[:, None, :]), -127, 127) + 127).astype(
+            np.uint8
+        )[None]
+        vals = x[0].transpose(0, 2, 1)[mask].astype(np.float16)  # (n_out, S)
+        return LLMInt8Container(codes, scale, mask, vals, x.shape)
+
+    def decompress(self, c: LLMInt8Container) -> np.ndarray:
+        out = c.scale[:, None, :] * _INT8_GRID[c.codes[0]]
+        out.transpose(0, 2, 1)[c.outlier_mask] = c.outlier_vals.astype(np.float32)
+        return out[None].astype(np.float32)
+
+    def grid_params(self, c: LLMInt8Container):
+        H, D = c.scale.shape
+        return np.zeros((H, D), dtype=np.float32), c.scale, _INT8_GRID
+
+    def codes(self, c: LLMInt8Container) -> np.ndarray:
+        return c.codes
+
+    def outlier_csr(self, c: LLMInt8Container):
+        if not c.outlier_mask.any():
+            return None
+        _, H, S, D = c.shape
+        dense = c.scale[:, None, :] * _INT8_GRID[c.codes[0]]  # (H, S, D)
+        h_idx, d_idx = np.nonzero(c.outlier_mask)
+        # token-major: for each (h, s), the outlier columns of head h
+        per_head = np.bincount(h_idx, minlength=H)  # outliers per head
+        counts = np.repeat(per_head, S)  # (H*S,)
+        row_ptr = np.zeros(H * S + 1, dtype=np.int32)
+        np.cumsum(counts, out=row_ptr[1:])
+        order = np.argsort(h_idx, kind="stable")
+        cols_by_head = [d_idx[order[h_idx[order] == h]] for h in range(H)]
+        cols = np.concatenate(
+            [np.tile(cbh, S) for cbh in cols_by_head if cbh.size]
+            or [np.zeros(0, np.int64)]
+        )
+        # deltas: fp16 value minus dense dequant, token-major within head
+        deltas = []
+        for h in range(H):
+            cbh = cols_by_head[h]
+            if not cbh.size:
+                continue
+            v = c.outlier_vals[
+                np.searchsorted(
+                    np.flatnonzero(c.outlier_mask.ravel()), h * c.scale.shape[1] + cbh
+                )
+            ].astype(
+                np.float32
+            )  # (n_h, S)
+            deltas.append((v.T - dense[h][:, cbh]).ravel())  # (S*n_h,)
+        deltas = np.concatenate(deltas) if deltas else np.zeros(0, np.float32)
+        return row_ptr, cols.astype(np.uint16), deltas.astype(np.float32)
+
+    def native_dtype(self):
+        return None
+
+
+SPEC_INT8 = PluginSpec(
+    name="bnb_llm_int8",
+    factory=LLMInt8Quantizer,
+    targets=frozenset({TARGET_KV_KEY, TARGET_WEIGHT}),
+    tier="experimental",
+    description=(
+        "LLM.int8 mixed decomposition: per-channel int8 absmax + fp16 "
+        "outlier channels surfaced as dense CSR columns -- fully "
+        "fused-decode-eligible through the affine contract"
+    ),
+)


### PR DESCRIPTION
LLM.int8 on the KV block convention: per-channel int8 absmax dense part (affine contract: `grid = arange(-127,128)`, weight `(H,D)`) + fp16 outlier **channels** surfaced through `outlier_csr` as dense per-token columns — the design doc's 'LLM.int8's decomposition is our overlay at column granularity' mapping, made executable. Conformance: affine **pass**, CSR **pass** → fully fused-decode-eligible, zero kernel changes. Registered as `bnb_llm_int8`. 9 plugin tests + registry suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)