### PR TITLE
P3: native fp8 KV passthrough (FP8NativeKV) with code-space oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 > install from `master` for the items below.
 
 ### Added
+- **Native fp8 KV passthrough** (P3; tqp_trtllm.native.FP8NativeKV):
+  keys/values stored as real torch.float8_e4m3fn tensors (half the
+  bytes of fp16) with per-head fp32 scale, upcast on read — the
+  hardware milestone of fp8_kv, honestly scoped to storage (fp8
+  compute is Hopper/FA3 territory). The code-space plugin is the
+  semantics oracle: torch RNE cast agrees with the 253-value grid to
+  1e-6 on real-shaped keys. CUDA-gated device test for the Ada leg.
 - **Keys comparison run — prediction refuted, boundary found**
   (P3; plugins/tqp-trtllm/examples/): on real Llama-3.2-3B keys, fp8
   (both scale modes, 8-bit float grid) is near-lossless — the

--- a/plugins/tqp-trtllm/tests/test_fp8_native.py
+++ b/plugins/tqp-trtllm/tests/test_fp8_native.py
@@ -1,0 +1,59 @@
+"""Native fp8 passthrough vs the code-space oracle."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+if not hasattr(torch, "float8_e4m3fn"):
+    pytest.skip("torch lacks float8_e4m3fn", allow_module_level=True)
+
+from tqp_trtllm.native import FP8NativeKV  # noqa: E402
+from tqp_trtllm.plugin import FP8KVQuantizer  # noqa: E402
+
+RNG = np.random.default_rng(5)
+
+
+def _keys():
+    off = RNG.uniform(-4, 4, size=(1, 4, 1, 64))
+    return (off + RNG.standard_normal((1, 4, 96, 64))).astype(np.float32)
+
+
+def test_native_matches_code_space_oracle():
+    x = _keys()
+    want = FP8KVQuantizer().decompress(FP8KVQuantizer().compress(x))
+    got = FP8NativeKV().decompress(FP8NativeKV().compress(x)).cpu().numpy()
+    # RNE cast vs nearest-table lookup: identical except exact ties
+    assert np.allclose(got, want, atol=1e-6), float(np.abs(got - want).max())
+
+
+def test_native_storage_is_half_of_fp16():
+    x = _keys()
+    c = FP8NativeKV().compress(x)
+    assert c.data.dtype == torch.float8_e4m3fn
+    fp16_bytes = x.size * 2
+    assert c.nbytes() < 0.55 * fp16_bytes
+
+
+def test_roundtrip_error_bounded():
+    x = _keys()
+    got = FP8NativeKV().decompress(FP8NativeKV().compress(x)).cpu().numpy()
+    rel = np.linalg.norm(got - x) / np.linalg.norm(x)
+    assert rel < 0.05  # fp8 with per-head scale is near-lossless on keys
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_native_on_cuda_device():
+    x = torch.as_tensor(_keys()).cuda()
+    c = FP8NativeKV().compress(x)
+    assert c.data.is_cuda and c.data.dtype == torch.float8_e4m3fn
+    out = FP8NativeKV().decompress(c)
+    assert out.is_cuda
+    assert torch.allclose(
+        out,
+        torch.as_tensor(
+            FP8KVQuantizer().decompress(FP8KVQuantizer().compress(x.cpu().numpy()))
+        ).cuda(),
+        atol=1e-6,
+    )

--- a/plugins/tqp-trtllm/tqp_trtllm/native.py
+++ b/plugins/tqp-trtllm/tqp_trtllm/native.py
@@ -1,0 +1,63 @@
+# tqp-trtllm: TensorRT-LLM-style KV formats as turboquant-pro plugins
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""Native fp8 (e4m3fn) KV passthrough — the hardware milestone of the
+``fp8_kv`` plugin's declared ``native_dtype``.
+
+Storage passthrough, honestly scoped: keys/values live as real
+``torch.float8_e4m3fn`` tensors (half the bytes of fp16) with a per-head
+fp32 scale, and are upcast on read for attention compute. Fp8 *compute*
+(scaled-mm attention) is Hopper/FlashAttention-3 territory; on Ada this
+storage form is the win available today. The code-space plugin
+(:class:`tqp_trtllm.plugin.FP8KVQuantizer`) is the semantics oracle: the
+torch cast rounds to nearest-even over exactly the 253-value finite e4m3fn
+grid, so native and code-space decompress must agree (ties excepted, which
+are measure-zero for real activations).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .plugin import _E4M3
+
+
+@dataclass
+class FP8NativeContainer:
+    data: object  # torch.Tensor, dtype float8_e4m3fn, shape (1, H, S, D)
+    scale: object  # torch.Tensor float32 (H,)
+    shape: tuple
+
+    def nbytes(self) -> int:
+        return self.data.element_size() * self.data.numel() + 4 * self.scale.numel()
+
+
+class FP8NativeKV:
+    """Per-head-scaled e4m3fn KV as real fp8 tensors (torch, any device)."""
+
+    def compress(self, x) -> FP8NativeContainer:
+        import torch
+
+        t = (
+            torch.as_tensor(np.asarray(x, dtype=np.float32))
+            if not hasattr(x, "dtype") or isinstance(x, np.ndarray)
+            else x
+        )
+        t = t.float()
+        if t.ndim != 4 or t.shape[0] != 1:
+            raise ValueError("expected the (1, H, S, D) block form")
+        H = t.shape[1]
+        scale = (t[0].abs().reshape(H, -1).amax(dim=1) / float(_E4M3[-1])).clamp_min(
+            1e-12
+        )
+        f8 = (t[0] / scale[:, None, None]).to(torch.float8_e4m3fn)[None]
+        return FP8NativeContainer(f8, scale, tuple(t.shape))
+
+    def decompress(self, c: FP8NativeContainer):
+        return (c.data[0].float() * c.scale[:, None, None])[None]
+
+    def native_dtype(self):
+        return "float8_e4m3fn"


### PR DESCRIPTION
The hardware milestone of `fp8_kv`'s declared `native_dtype`: keys/values as real `torch.float8_e4m3fn` tensors (half fp16 bytes, per-head fp32 scale, upcast on read). Honestly scoped to storage — fp8 compute is Hopper/FA3. The code-space plugin is the semantics oracle: torch RNE cast agrees with the 253-value grid to 1e-6. CUDA-gated test for the Ada leg (NRP validation job next). 9 tests green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)