### PR TITLE
P4 exit: resolve_plugins — operator_trace disciplines to named plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 > install from `master` for the items below.
 
 ### Added
+- **resolve_plugins** (P4 exit): model in, named recipe out —
+  operator_trace disciplines resolved to registered plugin names per
+  tensor and per target. On a Llama-shaped module: k_proj under
+  kv_activation → per_channel (protect_dc), q_proj under weight →
+  {gptq, awq, bnb_nf4}. Discipline from measurement, names from the
+  registry, nothing guessed.
 - **Native fp8 KV passthrough** (P3; tqp_trtllm.native.FP8NativeKV):
   keys/values stored as real torch.float8_e4m3fn tensors (half the
   bytes of fp16) with per-head fp32 scale, upcast on read — the

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -219,3 +219,56 @@ class TestAffineHelpers:
         assert np.array_equal(mu, mu2) and np.array_equal(w, w2)
         assert np.array_equal(np.asarray(g), np.asarray(g2))
         assert np.array_equal(q.codes(c), _codes(c))
+
+
+class TestResolvePlugins:
+    """P4 exit: model in, named recipe out -- operator_trace disciplines
+    resolved to registered plugin names, both quantization targets."""
+
+    def _model(self):
+        torch = pytest.importorskip("torch")
+        nn = torch.nn
+
+        class Attn(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q_proj = nn.Linear(32, 32, bias=False)
+                self.k_proj = nn.Linear(32, 32, bias=False)
+                self.v_proj = nn.Linear(32, 32, bias=False)
+                self.o_proj = nn.Linear(32, 32, bias=False)
+
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.self_attn = Attn()
+                self.up_proj = nn.Linear(32, 64, bias=False)
+
+        return M()
+
+    def test_kv_keys_resolve_to_per_channel_family(self):
+        from turboquant_pro.plugins import resolve_plugins
+
+        rec = resolve_plugins(self._model(), target="kv_activation")
+        k = next(v for n, v in rec.items() if "k_proj" in n)
+        assert k["family"] == "per_channel" and k["protect_dc"]
+        assert k["plugins"][0] == "per_channel"
+
+    def test_weights_resolve_to_gptq_awq_family_when_registered(self):
+        import sys
+
+        for pkg in ("plugins/tqp-gptq-awq", "plugins/tqp-bnb"):
+            sys.path.insert(0, pkg)
+        from tqp_bnb.plugin import SPEC_NF4
+        from tqp_gptq_awq.plugin import SPEC_AWQ, SPEC_GPTQ
+
+        from turboquant_pro.plugins import register, resolve_plugins
+
+        for spec in (SPEC_GPTQ, SPEC_AWQ, SPEC_NF4):
+            try:
+                register(spec)
+            except ValueError:
+                pass
+        rec = resolve_plugins(self._model(), target="weight")
+        q = next(v for n, v in rec.items() if "q_proj" in n)
+        assert q["family"] == "symmetric"
+        assert {"gptq", "awq", "bnb_nf4"} <= set(q["plugins"])

--- a/turboquant_pro/plugins.py
+++ b/turboquant_pro/plugins.py
@@ -60,6 +60,7 @@ __all__ = [
     "create",
     "available_plugins",
     "load_entry_point_plugins",
+    "resolve_plugins",
     "affine_params",
     "affine_codes",
     "outlier_csr",
@@ -347,3 +348,45 @@ register(
         ),
     )
 )
+
+
+# ------------------------------------------------------------------ #
+# operator_trace -> named plugins (the P4 model-in, recipe-out demo)  #
+# ------------------------------------------------------------------ #
+
+_FAMILY_PLUGINS: dict[str, list[str]] = {
+    # discipline family -> registered plugin names, best-evidenced first
+    "per_channel": ["per_channel", "bnb_llm_int8", "nvfp4_kv"],
+    "symmetric": ["gptq", "awq", "bnb_nf4", "fp8_kv"],
+    "polar": ["polar"],
+    "keep_fp": [],
+}
+
+
+def resolve_plugins(model, target: str = "weight", example_inputs=None):
+    """Model in, named recipe out: trace operator regimes
+    (:func:`turboquant_pro.operator_trace.recommend_quantization`), then map
+    each tensor's (A2) discipline to the plugin names actually present in the
+    registry (in-tree or entry-point discovered). Returns
+    ``{tensor_name: {"family": ..., "sensitivity": ..., "plugins": [...]}}``;
+    an empty list means keep full precision or install a plugin for that
+    family. This is the human-out-of-the-loop hand-off: the discipline comes
+    from measurement, the names come from the registry, nothing is guessed.
+    """
+    from .operator_trace import recommend_quantization
+
+    disciplines = recommend_quantization(
+        model, target=target, example_inputs=example_inputs
+    )
+    registered = available_plugins()
+    return {
+        name: {
+            "family": d.family,
+            "protect_dc": d.protect_dc,
+            "sensitivity": d.sensitivity,
+            "plugins": [
+                p for p in _FAMILY_PLUGINS.get(d.family, []) if p in registered
+            ],
+        }
+        for name, d in disciplines.items()
+    }


### PR DESCRIPTION
`resolve_plugins(model, target)`: trace regimes → (A2) discipline → registered plugin names, per tensor. k_proj under kv_activation → per_channel (protect_dc); q_proj under weight → {gptq, awq, bnb_nf4}. Discipline from measurement, names from the registry, nothing guessed. 22 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)