### PR TITLE
fix(torch_xp): constants follow the input device in reference paths

### DIFF
--- a/turboquant_pro/kv_fused.py
+++ b/turboquant_pro/kv_fused.py
@@ -21,7 +21,15 @@ from __future__ import annotations
 import numpy as np
 
 
-def _rot_matrices(tq, xp):
+def _align_device(a, like):
+    """Move ``a`` to ``like``'s device when both are torch tensors (constants
+    built from a CPU tq must follow CUDA/MPS inputs); no-op for numpy/cupy."""
+    if hasattr(like, "device") and hasattr(a, "to"):
+        return a.to(like.device)
+    return a
+
+
+def _rot_matrices(tq, xp, like=None):
     if getattr(tq, "_structured", False):
         raise NotImplementedError(
             "fused KV-decode reference currently supports full-QR rotations "
@@ -30,6 +38,8 @@ def _rot_matrices(tq, xp):
     pit = xp.asarray(tq._Pi_T, dtype=xp.float32)  # rotate:   x @ Pi_T
     pi = xp.asarray(tq._Pi, dtype=xp.float32)  # unrotate: y @ Pi
     cent = xp.asarray(tq.centroids, dtype=xp.float32)
+    if like is not None:
+        pit, pi, cent = (_align_device(a, like) for a in (pit, pi, cent))
     return pit, pi, cent
 
 
@@ -43,7 +53,7 @@ def fused_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
     """One decode-step attention output computed in code space (the fused path)."""
     kcodes, vcodes = xp.asarray(kcodes), xp.asarray(vcodes)
     d = q.shape[-1]
-    pit, pi, cent = _rot_matrices(tq, xp)
+    pit, pi, cent = _rot_matrices(tq, xp, like=q)
     q_rot = xp.asarray(q, dtype=xp.float32) @ pit
     scores = (
         xp.asarray(norm_k, dtype=xp.float32)
@@ -60,7 +70,7 @@ def dequant_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
     """Reference: reconstruct K/V to fp32, then standard attention (same math)."""
     kcodes, vcodes = xp.asarray(kcodes), xp.asarray(vcodes)
     d = q.shape[-1]
-    _, pi, cent = _rot_matrices(tq, xp)
+    _, pi, cent = _rot_matrices(tq, xp, like=q)
     k = xp.asarray(norm_k, dtype=xp.float32)[..., None] * (cent[kcodes] @ pi)
     v = xp.asarray(norm_v, dtype=xp.float32)[..., None] * (cent[vcodes] @ pi)
     scores = xp.einsum("hd,hsd->hs", xp.asarray(q, dtype=xp.float32), k) * (
@@ -73,7 +83,7 @@ def dequant_decode_attention(q, kcodes, vcodes, norm_k, norm_v, tq, xp=np):
 def _cold_partials(q, kcodes, vcodes, norm_k, norm_v, tq, scale, xp):
     """Unnormalized (m, l, acc) for cold (coded) keys/values, in real space."""
     kcodes, vcodes = xp.asarray(kcodes), xp.asarray(vcodes)
-    pit, pi, cent = _rot_matrices(tq, xp)
+    pit, pi, cent = _rot_matrices(tq, xp, like=q)
     q_rot = xp.asarray(q, dtype=xp.float32) @ pit
     sc = (
         xp.asarray(norm_k, dtype=xp.float32)

--- a/turboquant_pro/kv_fused_pck.py
+++ b/turboquant_pro/kv_fused_pck.py
@@ -214,7 +214,7 @@ class PreparedPCKBlock:
             return pck_block_partials_cuda(q, self, tq, scale=scale)
         from .kv_fused import _rot_matrices
 
-        _, pi, cent = _rot_matrices(tq, xp)
+        _, pi, cent = _rot_matrices(tq, xp, like=xp.asarray(q))
         sc = self.key_scores(q) * scale
         m = xp.amax(sc, axis=1)
         e = xp.exp(sc - m[:, None])
@@ -232,10 +232,12 @@ def pck_key_scores(q, q_kv: PerChannelKV, c: CompressedPerChannelKV, xp=np):
     B, H, S, D = c.shape
     mu, weight, grid = _grid_params(q_kv, c)
     codes = _codes(c)[0]  # (H, S, D)
+    from .kv_fused import _align_device
+
     qf = xp.asarray(q, dtype=xp.float32)
-    w = qf * xp.asarray(weight)  # (H, D) per-channel table weights
-    bias = (qf * xp.asarray(mu)).sum(axis=1)  # (H,) zero-point term, folded
-    g = xp.asarray(grid, dtype=xp.float32)
+    w = qf * _align_device(xp.asarray(weight), qf)  # per-channel table weights
+    bias = (qf * _align_device(xp.asarray(mu), qf)).sum(axis=1)  # zero-point
+    g = _align_device(xp.asarray(grid, dtype=xp.float32), qf)
 
     if _is_cupy(xp):
         from .volta_kernels import apply_outlier_csr, k2_key_scores
@@ -253,7 +255,8 @@ def pck_key_scores(q, q_kv: PerChannelKV, c: CompressedPerChannelKV, xp=np):
             )
         return scores
 
-    scores = xp.einsum("hd,hsd->hs", w, g[xp.asarray(codes)]) + bias[:, None]
+    codes_d = _align_device(xp.asarray(codes), qf)
+    scores = xp.einsum("hd,hsd->hs", w, g[codes_d]) + bias[:, None]
     csr = build_outlier_csr(q_kv, c)
     if csr is not None:
         row_ptr, cols, deltas = csr
@@ -273,7 +276,7 @@ def pck_cold_partials(q, q_kv, kc, vcodes, norm_v, tq, scale, xp=np):
     values -- the M4 analogue of ``kv_fused._cold_partials``."""
     from .kv_fused import _rot_matrices
 
-    _, pi, cent = _rot_matrices(tq, xp)
+    _, pi, cent = _rot_matrices(tq, xp, like=xp.asarray(q))
     sc = pck_key_scores(q, q_kv, kc, xp) * scale
     m = xp.amax(sc, axis=1)
     e = xp.exp(sc - m[:, None])


### PR DESCRIPTION
Found by the first real CUDA run of the `xp=torch_xp` paths (H100, lightning.ai trial): `_rot_matrices` constants built from the CPU tq landed on CPU vs cuda inputs → device-mismatch RuntimeError. `_rot_matrices` gains `like=` (torch-only `.to(device)`, no-op numpy/cupy); `pck_key_scores` aligns mu/weight/grid/codes via the shared `_align_device`. CPU suites unchanged and green. **Validate by rerunning the notebook cell on the H100** — the two `[cuda]` legs should flip to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)