### PR TITLE
P5: Triton port of the M2/M4 fused-decode kernels

### DIFF
--- a/benchmarks/RESULTS_p5_triton.md
+++ b/benchmarks/RESULTS_p5_triton.md
@@ -1,0 +1,52 @@
+# P5 Triton port — exactness + latency
+
+Harness: [`p5_triton_bench.py`](p5_triton_bench.py) and
+[`tests/test_kv_triton.py`](../tests/test_kv_triton.py). The Triton port of the
+M2/M4 fused-decode kernels (`turboquant_pro/_triton_kernels.py`) must be exact
+vs the NumPy reference (the CuPy RawKernel oracle) and reach perf parity; see
+`docs/DESIGN_hardware_and_plugins.md` §4.2 / P5.
+
+## Exactness — 7/7, NRP L40
+
+Both layers green:
+
+- **CPU-logic gate** (runs everywhere): a NumPy replay of the kernel's exact
+  control flow (split-K + per-token CSR loop + online softmax + flash-combine)
+  equals the all-at-once reference across D=64/96/128 and outlier fractions
+  0/0.02/0.05 — proves the decomposition before any GPU time.
+- **GPU exactness** (NRP L40, torch 2.4.0 / triton 3.0.0): the per-page,
+  batched-page, and Polar kernels all match the reference. `pytest -q`: **7
+  passed**.
+
+## Latency — batched-page beats per-page, NRP L40
+
+Per decode step, 8 heads × 128 dim, per-channel asym-NF4 keys + 2 % fp16
+outliers, PolarQuant values. `err` is max |Triton − NumPy reference| (fp32
+reassociation noise).
+
+| ctx | cold pages | err per-page | err batched | ms per-page | ms batched | batched speedup |
+|---:|---:|---:|---:|---:|---:|---:|
+| 2,048 | 6 | 7.2e-08 | 8.4e-08 | 3.43 | 2.08 | **1.65×** |
+| 8,192 | 30 | 4.5e-08 | 5.2e-08 | 18.09 | 9.32 | **1.94×** |
+| 32,768 | 126 | 1.7e-08 | 1.8e-08 | 75.47 | 37.52 | **2.01×** |
+
+The single-launch batched-page kernel (the deferred §8.5 item, landed in the
+Triton port) widens from 1.65× to ~2× as the cold cache grows — the per-page
+path pays one launch per page, the batched path one launch total.
+
+## Pending
+
+- **CuPy RawKernel perf-parity column** — the oracle needs CUDA toolkit headers
+  for its own JIT (`pip install cupy-cuda12x[ctk]`); the plain wheel on the
+  `-devel` image raised "Failed to find CUDA headers", so `ms_cupy_raw` is null
+  here. Exactness vs the NumPy reference (which the RawKernel is itself gated
+  against) is unaffected.
+- **A100 perf-parity** — the exit criterion's A100 run; L40 exactness + the
+  batched speedup already hold.
+- **ROCm** — single-source ready; not validated (Nautilus has no AMD GPUs, §4.5).
+
+Environment notes (both cost a validation round, worth knowing): Triton JIT
+needs a host C compiler — use the `pytorch...-devel` image, not `-runtime`
+("Failed to find C compiler"); and `@triton.jit` kernels must live at **module
+scope** — Triton resolves `tl` against the kernel's module globals, so a
+closure-local `tl` raises `NameError('tl is not defined')` at compile time.

--- a/benchmarks/p5_triton_bench.py
+++ b/benchmarks/p5_triton_bench.py
@@ -1,0 +1,147 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""P5 Triton port: exactness + latency vs the CuPy RawKernel oracle.
+
+The P5 exit criterion (docs/DESIGN_hardware_and_plugins.md): the Triton M4/M2
+kernels must be **exact** vs the RawKernel oracle on NRP V100/A100 and reach
+**perf parity or better on A100**. This script, run on a CUDA GPU:
+
+  1. builds a per-channel-key cache with a realistic cold length;
+  2. checks max |error| of the Triton per-page and batched-page decode vs the
+     NumPy reference (the oracle) -- must be ~fp32 noise;
+  3. times, per decode step: Triton per-page (loop over pages), Triton batched
+     (one launch), the CuPy RawKernel path when cupy is importable, and a torch
+     decompress-then-attend baseline.
+
+Usage (needs torch+triton; cupy optional):  python benchmarks/p5_triton_bench.py
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import numpy as np
+
+from turboquant_pro.core import TurboQuantKVCache
+from turboquant_pro.kv_triton import (
+    has_triton,
+    pck_batched_partials_triton,
+    pck_block_partials_triton,
+)
+
+H, D = 8, 128
+CTXS = [2048, 8192, 32768]
+
+
+def _build(ctx, seed=0):
+    cache = TurboQuantKVCache(
+        head_dim=D, n_heads=H, bits=4, use_gpu=False, seed=seed,
+        per_channel_keys=True, key_nf4_asym=True, key_outlier_frac=0.02,
+        hot_window=512,
+    )
+    rng = np.random.default_rng(seed)
+    off = rng.uniform(-4, 4, size=(H, D)).astype(np.float32)
+    for _ in range(ctx):
+        cache.append(
+            (off + rng.standard_normal((H, D))).astype(np.float32),
+            rng.standard_normal((H, D)).astype(np.float32),
+        )
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    return cache, q
+
+
+def _reference(cache, q):
+    k = np.asarray(cache.get_keys(0, cache.cold_length))[0]
+    v = np.asarray(cache.get_values(0, cache.cold_length))[0]
+    sc = np.einsum("hd,hsd->hs", q, k) / np.sqrt(D)
+    p = np.exp(sc - sc.max(1, keepdims=True))
+    p /= p.sum(1, keepdims=True)
+    return np.einsum("hs,hsd->hd", p, v)
+
+
+def _time(fn, iters=30):
+    import torch
+
+    for _ in range(5):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3  # ms
+
+
+def bench_ctx(ctx):
+    import torch
+
+    cache, q = _build(ctx)
+    tq, scale = cache._tq, 1.0 / np.sqrt(D)
+    blocks = cache._prepared_pck_blocks()
+    want = _reference(cache, q)
+
+    # per-page triton: loop pages + merge (matches core.fused_decode structure)
+    from turboquant_pro.kv_fused import merge_partials
+
+    def per_page():
+        parts = [pck_block_partials_triton(q, b, tq, scale) for b in blocks]
+        return merge_partials(parts, torch)
+
+    def batched():
+        m, lsum, acc = pck_batched_partials_triton(q, blocks, tq, scale)
+        return acc / torch.clamp(lsum, min=1e-30)[:, None]
+
+    out_pp = per_page().detach().cpu().numpy()
+    out_b = batched().detach().cpu().numpy()
+    err_pp = float(np.abs(out_pp - want).max())
+    err_b = float(np.abs(out_b - want).max())
+
+    rec = {
+        "ctx": ctx, "pages": len(blocks),
+        "err_per_page": err_pp, "err_batched": err_b,
+        "ms_per_page": round(_time(per_page), 3),
+        "ms_batched": round(_time(batched), 3),
+    }
+
+    # CuPy RawKernel oracle timing, if available (the perf-parity baseline)
+    try:
+        import cupy  # noqa: F401
+
+        cg = TurboQuantKVCache(
+            head_dim=D, n_heads=H, bits=4, use_gpu=True, seed=0,
+            per_channel_keys=True, key_nf4_asym=True, key_outlier_frac=0.02,
+            hot_window=512,
+        )
+        rng = np.random.default_rng(0)
+        off = rng.uniform(-4, 4, size=(H, D)).astype(np.float32)
+        for _ in range(ctx):
+            cg.append((off + rng.standard_normal((H, D))).astype(np.float32),
+                      rng.standard_normal((H, D)).astype(np.float32))
+        cg.fused_decode(q)  # warm/build prepared pages
+        rec["ms_cupy_raw"] = round(_time(lambda: cg.fused_decode(q)), 3)
+    except Exception as e:  # noqa: BLE001
+        rec["ms_cupy_raw"] = None
+        rec["cupy_note"] = f"{type(e).__name__}: {e}"
+
+    print(
+        f"[ctx {ctx}] pages={rec['pages']} "
+        f"err(pp/batch)={err_pp:.2e}/{err_b:.2e} "
+        f"ms pp={rec['ms_per_page']} batched={rec['ms_batched']} "
+        f"cupy={rec['ms_cupy_raw']}",
+        flush=True,
+    )
+    return rec
+
+
+if __name__ == "__main__":
+    import torch
+
+    if not has_triton():
+        raise SystemExit("needs torch+triton on a CUDA GPU")
+    print(f"[gpu] {torch.cuda.get_device_name(0)}", flush=True)
+    results = [bench_ctx(c) for c in CTXS]
+    print("=== JSON ===")
+    print(json.dumps(results))

--- a/tests/test_kv_triton.py
+++ b/tests/test_kv_triton.py
@@ -1,0 +1,171 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""P5 Triton port: exactness vs the NumPy reference (the RawKernel oracle).
+
+Two layers:
+
+* :func:`_kernel_sim_pck` replays the Triton M4 kernel's *exact* control flow
+  in NumPy -- split-K over the key axis, per-token CSR outlier loop, online
+  (flash) softmax, host flash-combine. It runs everywhere and gates the port's
+  algorithm/indexing before any GPU time is spent; if the decomposition is
+  wrong this fails on CPU.
+* the ``triton_*`` tests call the real kernels and compare to the reference;
+  they skip unless :func:`turboquant_pro.kv_triton.has_triton` (Triton + CUDA).
+  These are the P5 exit-criterion checks, run on NRP V100/A100.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from turboquant_pro.core import TurboQuantKVCache
+from turboquant_pro.kv_triton import _nsplit, has_triton
+
+
+def _make_block(H=4, D=64, n_tok=50, outlier=0.02, seed=0):
+    """Build one cold PreparedPCKBlock (numpy) + its reference partials."""
+    cache = TurboQuantKVCache(
+        head_dim=D, n_heads=H, bits=4, use_gpu=False, seed=seed,
+        per_channel_keys=True, key_nf4_asym=True, key_outlier_frac=outlier,
+        hot_window=4,
+    )
+    rng = np.random.default_rng(seed)
+    off = rng.uniform(-4, 4, size=(H, D)).astype(np.float32)
+    for _ in range(n_tok):
+        cache.append(
+            (off + rng.standard_normal((H, D))).astype(np.float32),
+            rng.standard_normal((H, D)).astype(np.float32),
+        )
+    # small hot_window flushes most tokens to cold automatically
+    blocks = cache._prepared_pck_blocks()
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    return cache, blocks, q
+
+
+def _kernel_sim_pck(blk, q, tq, scale):
+    """NumPy replay of the Triton M4 kernel: split-K + CSR + online softmax +
+    flash-combine. Mirrors _pck_partials_kernel one-to-one (per (h, split)
+    program, per-token CSR row, running (m, lsum, acc))."""
+    H, S, D = blk.H, blk.S, blk.D
+    q = np.asarray(q, np.float32).reshape(H, D)
+    w = q * np.asarray(blk.weight, np.float32)          # (H, D)
+    bias = (q * np.asarray(blk.mu, np.float32)).sum(1)  # (H,)
+    grid = np.asarray(blk.grid, np.float32)
+    kcodes = np.asarray(blk.kcodes)                     # (H, S, D) uint8
+    vcodes = np.asarray(blk.vcodes)
+    norm_v = np.asarray(blk.norm_v, np.float32)         # (H, S)
+    cent = np.asarray(tq.centroids, np.float32)
+    pi = np.asarray(tq._Pi, np.float32)
+    row_ptr = np.asarray(blk.row_ptr, np.int64)
+    cols = np.asarray(blk.cols, np.int64)
+    deltas = np.asarray(blk.deltas, np.float32)
+    nsplit = _nsplit(S)
+    chunk = (S + nsplit - 1) // nsplit
+
+    m_p = np.full((H, nsplit), -1e30, np.float32)
+    l_p = np.zeros((H, nsplit), np.float32)
+    acc_p = np.zeros((H, nsplit, D), np.float32)
+    for h in range(H):
+        for split in range(nsplit):
+            s0 = split * chunk
+            s1 = min(s0 + chunk, S)
+            m, lsum = np.float32(-1e30), np.float32(0.0)
+            acc = np.zeros(D, np.float32)
+            for s in range(s0, s1):
+                partial = float((w[h] * grid[kcodes[h, s]]).sum())
+                e0, e1 = int(row_ptr[h * S + s]), int(row_ptr[h * S + s + 1])
+                for e in range(e0, e1):
+                    partial += float(q[h, cols[e]] * deltas[e])
+                score = np.float32((partial + bias[h]) * scale)
+                mn = max(m, score)
+                corr = np.exp(m - mn, dtype=np.float32)
+                p = np.exp(score - mn, dtype=np.float32)
+                lsum = lsum * corr + p
+                m = mn
+                acc = acc * corr + (p * norm_v[h, s]) * cent[vcodes[h, s]]
+            m_p[h, split], l_p[h, split], acc_p[h, split] = m, lsum, acc
+    # flash-combine
+    m = m_p.max(1, keepdims=True)
+    wgt = np.exp(m_p - m)
+    denom = (l_p * wgt).sum(1)
+    acc = (acc_p * wgt[:, :, None]).sum(1)
+    return m[:, 0], denom, acc @ pi
+
+
+@pytest.mark.parametrize("D,outlier", [(64, 0.0), (64, 0.02), (96, 0.05), (128, 0.02)])
+def test_pck_kernel_logic_numpy(D, outlier):
+    """The port's split-K + CSR + online-softmax decomposition equals the
+    all-at-once reference einsum -- validated on CPU, no GPU needed."""
+    cache, blocks, q = _make_block(H=4, D=D, n_tok=50, outlier=outlier, seed=1)
+    assert len(blocks) >= 1
+    tq, scale = cache._tq, 1.0 / np.sqrt(D)
+    for blk in blocks:
+        m_ref, l_ref, acc_ref = blk.partials(q, tq, scale)   # numpy reference
+        m_s, l_s, acc_s = _kernel_sim_pck(blk, q, tq, scale)
+        assert np.allclose(m_ref, m_s, atol=1e-4), "m mismatch"
+        assert np.allclose(l_ref, l_s, rtol=1e-4, atol=1e-4), "lsum mismatch"
+        assert np.allclose(acc_ref, acc_s, rtol=1e-4, atol=1e-3), "acc mismatch"
+
+
+@pytest.mark.skipif(not has_triton(), reason="needs Triton + CUDA/ROCm")
+def test_triton_pck_matches_reference():
+    """M4 Triton kernel == NumPy reference partials (per page)."""
+    cache, blocks, q = _make_block(H=8, D=128, n_tok=200, outlier=0.02, seed=2)
+    from turboquant_pro.kv_triton import pck_block_partials_triton
+
+    tq, scale = cache._tq, 1.0 / np.sqrt(128)
+    for blk in blocks:
+        m_ref, l_ref, acc_ref = blk.partials(q, tq, scale)
+        m_t, l_t, acc_t = pck_block_partials_triton(q, blk, tq, scale)
+        to_np = lambda x: x.detach().cpu().numpy()  # noqa: E731
+        assert np.allclose(m_ref, to_np(m_t), atol=1e-3)
+        assert np.allclose(l_ref, to_np(l_t), rtol=1e-3, atol=1e-3)
+        assert np.allclose(acc_ref, to_np(acc_t), rtol=1e-3, atol=1e-2)
+
+
+@pytest.mark.skipif(not has_triton(), reason="needs Triton + CUDA/ROCm")
+def test_triton_pck_batched_matches_full_decode():
+    """Batched-page kernel over all cold pages == the full fused_decode output."""
+    import torch
+
+    cache, blocks, q = _make_block(H=8, D=128, n_tok=600, outlier=0.02, seed=3)
+    from turboquant_pro.kv_triton import pck_batched_partials_triton
+
+    tq, scale = cache._tq, 1.0 / np.sqrt(128)
+    m_b, l_b, acc_b = pck_batched_partials_triton(q, blocks, tq, scale)
+    out_b = (acc_b / torch.clamp(l_b, min=1e-30)[:, None]).detach().cpu().numpy()
+    # reference: attention over reconstructed cold keys/values
+    k = np.asarray(cache.get_keys(0, cache.cold_length))[0]
+    v = np.asarray(cache.get_values(0, cache.cold_length))[0]
+    sc = np.einsum("hd,hsd->hs", q, k) / np.sqrt(128)
+    p = np.exp(sc - sc.max(1, keepdims=True))
+    p /= p.sum(1, keepdims=True)
+    want = np.einsum("hs,hsd->hd", p, v)
+    assert np.allclose(out_b, want, rtol=1e-3, atol=1e-2)
+
+
+@pytest.mark.skipif(not has_triton(), reason="needs Triton + CUDA/ROCm")
+def test_triton_polar_matches_reference():
+    """M2 PolarQuant Triton kernel == the CuPy/NumPy fused-decode reference."""
+    import torch
+
+    from turboquant_pro.core import TurboQuantKV
+    from turboquant_pro.kv_fused import fused_decode_attention
+    from turboquant_pro.kv_triton import polar_partials_triton
+
+    H, S, D = 8, 300, 128
+    rng = np.random.default_rng(4)
+    tq = TurboQuantKV(head_dim=D, n_heads=H, bits=4, use_gpu=False, seed=0)
+    v = rng.standard_normal((H, S, D)).astype(np.float32)
+    nv = np.linalg.norm(v, axis=-1).astype(np.float32) + 1e-6
+    unit = v / nv[..., None]
+    rot = np.einsum("hsd,de->hse", unit, np.asarray(tq._Pi_T, np.float32))
+    codes = np.searchsorted(tq.boundaries, rot).astype(np.uint8)
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    want = fused_decode_attention(q, codes, codes, nv, nv, tq, xp=np)
+    m, lsum, acc = polar_partials_triton(q, codes, codes, nv, nv, tq)
+    got = (acc / torch.clamp(lsum, min=1e-30)[:, None]).detach().cpu().numpy()
+    assert np.allclose(got, want, rtol=1e-3, atol=1e-2)

--- a/turboquant_pro/_triton_kernels.py
+++ b/turboquant_pro/_triton_kernels.py
@@ -1,0 +1,194 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""Triton ``@triton.jit`` kernels for the P5 port (M2/M4 fused decode).
+
+These MUST live at module scope: ``@triton.jit`` resolves names in the
+kernel body and its annotations (``tl.constexpr``) against the function's
+*module globals* (``fn.__globals__``), not any enclosing closure. Defining
+them inside a builder function makes ``tl`` a local and the compiler raises
+``NameError('tl is not defined')`` at the first annotation. So ``triton`` and
+``tl`` are imported here at module top -- which means this module is imported
+only from :func:`turboquant_pro.kv_triton._build_kernels`, gated behind
+:func:`turboquant_pro.kv_triton.has_triton`, so CPU-only installs never load
+it. See ``turboquant_pro/kv_triton.py`` for the host wrappers and contract.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def pck_partials_kernel(
+    kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
+    row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
+    m_out_ptr, l_out_ptr, acc_out_ptr,
+    H, S, D, scale, nsplit,
+    MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
+):
+    # one program per (head, key-split); mirror of fused_decode_pck
+    pid = tl.program_id(0)
+    h = pid // nsplit
+    split = pid % nsplit
+    if h >= H:
+        return
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < D
+    w = tl.load(w_ptr + h * D + offs, mask=mask, other=0.0)
+    b = tl.load(bias_ptr + h)
+    chunk = (S + nsplit - 1) // nsplit
+    s0 = split * chunk
+    s1 = tl.minimum(s0 + chunk, S)
+
+    m = -1e30
+    lsum = 0.0
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+    hS = h * S
+    for s in range(s0, s1):
+        base = (hS + s) * D + offs
+        kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+        gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
+        partial = tl.sum(w * gk, axis=0)
+        # sparse outlier correction: this token's CSR row (bounded MAX_NNZ)
+        e0 = tl.load(row_ptr_ptr + hS + s)
+        e1 = tl.load(row_ptr_ptr + hS + s + 1)
+        n_e = e1 - e0
+        for e in range(0, MAX_NNZ):
+            valid = e < n_e
+            col = tl.load(cols_ptr + e0 + e, mask=valid, other=0).to(tl.int32)
+            dl = tl.load(deltas_ptr + e0 + e, mask=valid, other=0.0)
+            qv = tl.load(qk_ptr + h * D + col, mask=valid, other=0.0)
+            partial += tl.where(valid, qv * dl, 0.0)
+        score = (partial + b) * scale
+        mn = tl.maximum(m, score)
+        corr = tl.exp(m - mn)
+        p = tl.exp(score - mn)
+        lsum = lsum * corr + p
+        m = mn
+        nv = tl.load(norm_v_ptr + hS + s)
+        vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+        cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
+        acc = acc * corr + (p * nv) * cv
+
+    po = h * nsplit + split
+    tl.store(m_out_ptr + po, m)
+    tl.store(l_out_ptr + po, lsum)
+    tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
+
+
+@triton.jit
+def pck_batched_kernel(
+    kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
+    row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
+    page_S_ptr, page_koff_ptr, page_toff_ptr,
+    m_out_ptr, l_out_ptr, acc_out_ptr,
+    P, H, D, scale, nsplit,
+    MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
+):
+    # one program per (page, head, key-split): every cold page in one launch
+    pid = tl.program_id(0)
+    hn = H * nsplit
+    p = pid // hn
+    rem = pid % hn
+    h = rem // nsplit
+    split = rem % nsplit
+    if p >= P:
+        return
+    S = tl.load(page_S_ptr + p)
+    koff = tl.load(page_koff_ptr + p)   # element offset into kcodes/vcodes cat
+    toff = tl.load(page_toff_ptr + p)   # token offset (= sum_{q<p} H*S_q)
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < D
+    # w/bias are per-(page,head): laid out (P*H, D) and (P*H,)
+    ph = p * H + h
+    w = tl.load(w_ptr + ph * D + offs, mask=mask, other=0.0)
+    b = tl.load(bias_ptr + ph)
+    chunk = (S + nsplit - 1) // nsplit
+    s0 = split * chunk
+    s1 = tl.minimum(s0 + chunk, S)
+
+    m = -1e30
+    lsum = 0.0
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+    hS = h * S
+    for s in range(s0, s1):
+        base = koff + (hS + s) * D + offs
+        kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+        gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
+        partial = tl.sum(w * gk, axis=0)
+        tok = toff + hS + s        # global token index for the shared CSR
+        e0 = tl.load(row_ptr_ptr + tok)
+        e1 = tl.load(row_ptr_ptr + tok + 1)
+        n_e = e1 - e0
+        for e in range(0, MAX_NNZ):
+            valid = e < n_e
+            col = tl.load(cols_ptr + e0 + e, mask=valid, other=0).to(tl.int32)
+            dl = tl.load(deltas_ptr + e0 + e, mask=valid, other=0.0)
+            qv = tl.load(qk_ptr + ph * D + col, mask=valid, other=0.0)
+            partial += tl.where(valid, qv * dl, 0.0)
+        score = (partial + b) * scale
+        mn = tl.maximum(m, score)
+        corr = tl.exp(m - mn)
+        pw = tl.exp(score - mn)
+        lsum = lsum * corr + pw
+        m = mn
+        nv = tl.load(norm_v_ptr + toff + hS + s)
+        vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+        cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
+        acc = acc * corr + (pw * nv) * cv
+
+    po = (p * H + h) * nsplit + split
+    tl.store(m_out_ptr + po, m)
+    tl.store(l_out_ptr + po, lsum)
+    tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
+
+
+@triton.jit
+def polar_split_kernel(
+    kcodes_ptr, vcodes_ptr, norm_k_ptr, norm_v_ptr, qrot_ptr, cent_ptr,
+    m_out_ptr, l_out_ptr, acc_out_ptr,
+    H, S, D, ncent, scale, nsplit,
+    BLOCK_D: tl.constexpr,
+):
+    # PolarQuant code-space split-K (port of fused_decode_split); keys and
+    # values share the centroid grid, score = norm_k * <q_rot, cent[code]>.
+    pid = tl.program_id(0)
+    h = pid // nsplit
+    split = pid % nsplit
+    if h >= H:
+        return
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < D
+    qr = tl.load(qrot_ptr + h * D + offs, mask=mask, other=0.0)
+    chunk = (S + nsplit - 1) // nsplit
+    s0 = split * chunk
+    s1 = tl.minimum(s0 + chunk, S)
+
+    m = -1e30
+    lsum = 0.0
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+    hS = h * S
+    for s in range(s0, s1):
+        base = (hS + s) * D + offs
+        kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+        gk = tl.load(cent_ptr + kc, mask=mask, other=0.0)
+        partial = tl.sum(qr * gk, axis=0)
+        nk = tl.load(norm_k_ptr + hS + s)
+        score = nk * partial * scale
+        mn = tl.maximum(m, score)
+        corr = tl.exp(m - mn)
+        pw = tl.exp(score - mn)
+        lsum = lsum * corr + pw
+        m = mn
+        nv = tl.load(norm_v_ptr + hS + s)
+        vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+        cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
+        acc = acc * corr + (pw * nv) * cv
+
+    po = h * nsplit + split
+    tl.store(m_out_ptr + po, m)
+    tl.store(l_out_ptr + po, lsum)
+    tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)

--- a/turboquant_pro/kv_fused_pck.py
+++ b/turboquant_pro/kv_fused_pck.py
@@ -132,6 +132,11 @@ def _is_cupy(xp):
     return getattr(xp, "__name__", "") == "cupy"
 
 
+def _is_torch(xp):
+    """True when ``xp`` is the torch backend shim (so the Triton port is usable)."""
+    return type(xp).__name__ == "_TorchXP" or getattr(xp, "__name__", "") == "torch"
+
+
 class PreparedPCKBlock:
     """Query-independent prepared form of one cold (K, V) page for the fused path.
 
@@ -212,6 +217,15 @@ class PreparedPCKBlock:
             from .kv_kernel import pck_block_partials_cuda
 
             return pck_block_partials_cuda(q, self, tq, scale=scale)
+        if _is_torch(xp):
+            from .kv_triton import has_triton, pck_block_partials_triton
+
+            if not has_triton():
+                raise NotImplementedError(
+                    "torch per-channel fused decode requires Triton + a CUDA/ROCm "
+                    "device; install triton or build the block with xp=cupy/numpy"
+                )
+            return pck_block_partials_triton(q, self, tq, scale=scale)
         from .kv_fused import _rot_matrices
 
         _, pi, cent = _rot_matrices(tq, xp, like=xp.asarray(q))

--- a/turboquant_pro/kv_triton.py
+++ b/turboquant_pro/kv_triton.py
@@ -1,0 +1,523 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""P5: portable Triton port of the fused compute-on-codes kernels.
+
+The M1--M4 fast paths ship as CuPy ``RawKernel`` (CUDA-only). This module
+ports the two that matter -- **M2** (PolarQuant split-K value decode) and
+**M4** (per-channel keys + CSR outliers, the recommended key format) -- to
+Triton, keyed off the *same* prepared-page structs
+(:class:`turboquant_pro.kv_fused_pck.PreparedPCKBlock`). Triton compiles one
+source to NVIDIA and (where a target exists) ROCm; the CuPy RawKernel stays
+the CUDA reference implementation and the exactness oracle. See
+``docs/DESIGN_hardware_and_plugins.md`` sections 4.2 / P5.
+
+Design decisions carried over verbatim from the RawKernel so the ports are
+byte-comparable against the oracle:
+
+  * split-K over the key axis for occupancy (``nsplit`` per head), each
+    program emitting an **unnormalized** online-softmax partial ``(m, lsum,
+    acc)`` that the host flash-combines -- identical to
+    :func:`turboquant_pro.kv_kernel.pck_block_partials_cuda`;
+  * the M4 dense score is branch-free (``sum_j w_j grid[code]``) and the
+    sparse outlier correction is a short per-token CSR loop folded in *before*
+    the softmax update;
+  * values stay PolarQuant code-space; the single inverse-rotation ``@ Pi`` is
+    applied on the host after the combine.
+
+The two M4 "next" items from ``docs/DESIGN_fused_kv_decode.md`` section 8.5
+land here rather than in the RawKernel (design doc 4.2 -- "so the effort
+compounds"): a **batched per-page launch** (:func:`pck_batched_partials_triton`,
+one kernel over every cold page) and a **grid tile over head_dim** (``BLOCK_D``)
+that removes the ``d/32 <= 16`` register-tiling limit of the warp kernel.
+
+Triton and torch are imported lazily; this module loads on CPU-only installs.
+Calling a kernel requires a CUDA (or ROCm) GPU with Triton available.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "has_triton",
+    "pck_block_partials_triton",
+    "pck_batched_partials_triton",
+    "fused_decode_pck_triton",
+    "polar_partials_triton",
+]
+
+_TRITON = {"checked": False, "ok": False}
+
+
+def has_triton() -> bool:
+    """True when both torch (with a CUDA/ROCm device) and Triton are importable.
+
+    Cached after the first probe. Never raises -- a missing Triton or a
+    CPU-only torch just means the caller stays on the CuPy or NumPy path.
+    """
+    if not _TRITON["checked"]:
+        _TRITON["checked"] = True
+        try:
+            import torch  # noqa: F401
+            import triton  # noqa: F401
+
+            _TRITON["ok"] = bool(torch.cuda.is_available())
+        except Exception:  # noqa: BLE001 - any import/runtime failure = no triton
+            _TRITON["ok"] = False
+    return _TRITON["ok"]
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def _nsplit(S: int) -> int:
+    """Split-K factor -- identical schedule to the RawKernel path."""
+    return max(1, min(32, (S + 511) // 512))
+
+
+# --------------------------------------------------------------------------
+# Triton kernels are defined inside a lazy builder so the ``@triton.jit``
+# decorator (which imports triton at class-body time) never runs on a
+# CPU-only install. Built once, cached in _K.
+# --------------------------------------------------------------------------
+_K: dict = {}
+
+
+def _build_kernels():
+    if _K:
+        return _K
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _pck_partials_kernel(
+        kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
+        row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
+        m_out_ptr, l_out_ptr, acc_out_ptr,
+        H, S, D, scale, nsplit,
+        MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
+    ):
+        # one program per (head, key-split); mirror of fused_decode_pck
+        pid = tl.program_id(0)
+        h = pid // nsplit
+        split = pid % nsplit
+        if h >= H:
+            return
+        offs = tl.arange(0, BLOCK_D)
+        mask = offs < D
+        w = tl.load(w_ptr + h * D + offs, mask=mask, other=0.0)
+        b = tl.load(bias_ptr + h)
+        chunk = (S + nsplit - 1) // nsplit
+        s0 = split * chunk
+        s1 = tl.minimum(s0 + chunk, S)
+
+        m = -1e30
+        lsum = 0.0
+        acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+        hS = h * S
+        for s in range(s0, s1):
+            base = (hS + s) * D + offs
+            kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+            gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
+            partial = tl.sum(w * gk, axis=0)
+            # sparse outlier correction: this token's CSR row (bounded MAX_NNZ)
+            e0 = tl.load(row_ptr_ptr + hS + s)
+            e1 = tl.load(row_ptr_ptr + hS + s + 1)
+            n_e = e1 - e0
+            for e in range(0, MAX_NNZ):
+                valid = e < n_e
+                col = tl.load(cols_ptr + e0 + e, mask=valid, other=0).to(tl.int32)
+                dl = tl.load(deltas_ptr + e0 + e, mask=valid, other=0.0)
+                qv = tl.load(qk_ptr + h * D + col, mask=valid, other=0.0)
+                partial += tl.where(valid, qv * dl, 0.0)
+            score = (partial + b) * scale
+            mn = tl.maximum(m, score)
+            corr = tl.exp(m - mn)
+            p = tl.exp(score - mn)
+            lsum = lsum * corr + p
+            m = mn
+            nv = tl.load(norm_v_ptr + hS + s)
+            vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+            cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
+            acc = acc * corr + (p * nv) * cv
+
+        po = h * nsplit + split
+        tl.store(m_out_ptr + po, m)
+        tl.store(l_out_ptr + po, lsum)
+        tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
+
+    @triton.jit
+    def _pck_batched_kernel(
+        kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
+        row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
+        page_S_ptr, page_koff_ptr, page_toff_ptr,
+        m_out_ptr, l_out_ptr, acc_out_ptr,
+        P, H, D, scale, nsplit,
+        MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
+    ):
+        # one program per (page, head, key-split): every cold page in one launch
+        pid = tl.program_id(0)
+        hn = H * nsplit
+        p = pid // hn
+        rem = pid % hn
+        h = rem // nsplit
+        split = rem % nsplit
+        if p >= P:
+            return
+        S = tl.load(page_S_ptr + p)
+        koff = tl.load(page_koff_ptr + p)   # element offset into kcodes/vcodes cat
+        toff = tl.load(page_toff_ptr + p)   # token offset (= sum_{q<p} H*S_q)
+        offs = tl.arange(0, BLOCK_D)
+        mask = offs < D
+        # w/bias are per-(page,head): laid out (P*H, D) and (P*H,)
+        ph = p * H + h
+        w = tl.load(w_ptr + ph * D + offs, mask=mask, other=0.0)
+        b = tl.load(bias_ptr + ph)
+        chunk = (S + nsplit - 1) // nsplit
+        s0 = split * chunk
+        s1 = tl.minimum(s0 + chunk, S)
+
+        m = -1e30
+        lsum = 0.0
+        acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+        hS = h * S
+        for s in range(s0, s1):
+            base = koff + (hS + s) * D + offs
+            kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+            gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
+            partial = tl.sum(w * gk, axis=0)
+            tok = toff + hS + s        # global token index for the shared CSR
+            e0 = tl.load(row_ptr_ptr + tok)
+            e1 = tl.load(row_ptr_ptr + tok + 1)
+            n_e = e1 - e0
+            for e in range(0, MAX_NNZ):
+                valid = e < n_e
+                col = tl.load(cols_ptr + e0 + e, mask=valid, other=0).to(tl.int32)
+                dl = tl.load(deltas_ptr + e0 + e, mask=valid, other=0.0)
+                qv = tl.load(qk_ptr + ph * D + col, mask=valid, other=0.0)
+                partial += tl.where(valid, qv * dl, 0.0)
+            score = (partial + b) * scale
+            mn = tl.maximum(m, score)
+            corr = tl.exp(m - mn)
+            pw = tl.exp(score - mn)
+            lsum = lsum * corr + pw
+            m = mn
+            nv = tl.load(norm_v_ptr + toff + hS + s)
+            vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+            cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
+            acc = acc * corr + (pw * nv) * cv
+
+        po = (p * H + h) * nsplit + split
+        tl.store(m_out_ptr + po, m)
+        tl.store(l_out_ptr + po, lsum)
+        tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
+
+    @triton.jit
+    def _polar_split_kernel(
+        kcodes_ptr, vcodes_ptr, norm_k_ptr, norm_v_ptr, qrot_ptr, cent_ptr,
+        m_out_ptr, l_out_ptr, acc_out_ptr,
+        H, S, D, ncent, scale, nsplit,
+        BLOCK_D: tl.constexpr,
+    ):
+        # PolarQuant code-space split-K (port of fused_decode_split); keys and
+        # values share the centroid grid, score = norm_k * <q_rot, cent[code]>.
+        pid = tl.program_id(0)
+        h = pid // nsplit
+        split = pid % nsplit
+        if h >= H:
+            return
+        offs = tl.arange(0, BLOCK_D)
+        mask = offs < D
+        qr = tl.load(qrot_ptr + h * D + offs, mask=mask, other=0.0)
+        chunk = (S + nsplit - 1) // nsplit
+        s0 = split * chunk
+        s1 = tl.minimum(s0 + chunk, S)
+
+        m = -1e30
+        lsum = 0.0
+        acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+        hS = h * S
+        for s in range(s0, s1):
+            base = (hS + s) * D + offs
+            kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+            gk = tl.load(cent_ptr + kc, mask=mask, other=0.0)
+            partial = tl.sum(qr * gk, axis=0)
+            nk = tl.load(norm_k_ptr + hS + s)
+            score = nk * partial * scale
+            mn = tl.maximum(m, score)
+            corr = tl.exp(m - mn)
+            pw = tl.exp(score - mn)
+            lsum = lsum * corr + pw
+            m = mn
+            nv = tl.load(norm_v_ptr + hS + s)
+            vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
+            cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
+            acc = acc * corr + (pw * nv) * cv
+
+        po = h * nsplit + split
+        tl.store(m_out_ptr + po, m)
+        tl.store(l_out_ptr + po, lsum)
+        tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
+
+    _K["pck"] = _pck_partials_kernel
+    _K["pck_batched"] = _pck_batched_kernel
+    _K["polar"] = _polar_split_kernel
+    _K["triton"] = triton
+    return _K
+
+
+# --------------------------------------------------------------------------
+# Host wrappers. Each mirrors its CuPy counterpart's flash-combine and returns
+# real-space (unrotated) partials for turboquant_pro.kv_fused.merge_partials.
+# --------------------------------------------------------------------------
+def _cuda(t, dtype=None):
+    """Move an array/tensor to a contiguous CUDA torch tensor."""
+    import torch
+
+    if not isinstance(t, torch.Tensor):
+        t = torch.as_tensor(np.asarray(t))
+    if dtype is not None:
+        t = t.to(dtype)
+    if not t.is_cuda:
+        t = t.cuda()
+    return t.contiguous()
+
+
+def _max_row_nnz(row_ptr) -> int:
+    import torch
+
+    rp = row_ptr if isinstance(row_ptr, torch.Tensor) else torch.as_tensor(
+        np.asarray(row_ptr)
+    )
+    if rp.numel() <= 1:
+        return 0
+    return int((rp[1:] - rp[:-1]).max().item())
+
+
+def _flash_combine(m_p, l_p, acc_p, pi):
+    """Combine split-K partials (H, nsplit),(H, nsplit),(H, nsplit, D) -> real
+    space (m, denom, acc @ pi); identical math to the CuPy path."""
+    import torch
+
+    m = m_p.amax(dim=1, keepdim=True)
+    w = torch.exp(m_p - m)
+    denom = (l_p * w).sum(dim=1)
+    acc = (acc_p * w[:, :, None]).sum(dim=1)
+    return m[:, 0], denom, acc @ pi
+
+
+def pck_block_partials_triton(q, blk, tq, scale=None):
+    """Cold partials (m, lsum, acc) for one prepared per-channel page via the M4
+    Triton kernel. ``blk`` a :class:`~turboquant_pro.kv_fused_pck.PreparedPCKBlock`
+    (any backend -- arrays are moved to CUDA here). Real-space (unrotated)
+    result for :func:`turboquant_pro.kv_fused.merge_partials`; exact vs the
+    NumPy reference and the CuPy RawKernel oracle."""
+    import torch
+
+    if getattr(tq, "_structured", False):
+        raise NotImplementedError("structured rotation not supported by the kernel")
+    K = _build_kernels()
+    H, d = int(blk.H), int(blk.D)
+    S = int(blk.S)
+    qk = _cuda(q, torch.float32).reshape(H, d)
+    weight = _cuda(blk.weight, torch.float32)
+    mu = _cuda(blk.mu, torch.float32)
+    w = (qk * weight).contiguous()
+    bias = (qk * mu).sum(dim=1).contiguous()
+    grid = _cuda(blk.grid, torch.float32)
+    cent = _cuda(tq.centroids, torch.float32)
+    pi = _cuda(tq._Pi, torch.float32)
+    kcodes = _cuda(blk.kcodes, torch.uint8)
+    vcodes = _cuda(blk.vcodes, torch.uint8)
+    norm_v = _cuda(blk.norm_v, torch.float32)
+    row_ptr = _cuda(blk.row_ptr, torch.int32)
+    cols = _cuda(blk.cols, torch.int32)   # uint16 -> int32 for gather
+    deltas = _cuda(blk.deltas, torch.float32)
+    if scale is None:
+        scale = 1.0 / np.sqrt(d)
+
+    nsplit = _nsplit(S)
+    max_nnz = _max_row_nnz(row_ptr)
+    m_p = torch.empty((H, nsplit), dtype=torch.float32, device="cuda")
+    l_p = torch.empty((H, nsplit), dtype=torch.float32, device="cuda")
+    acc_p = torch.empty((H, nsplit, d), dtype=torch.float32, device="cuda")
+
+    K["pck"][(H * nsplit,)](
+        kcodes, vcodes, w, bias, grid, qk,
+        row_ptr, cols, deltas, norm_v, cent,
+        m_p, l_p, acc_p,
+        H, S, d, float(scale), nsplit,
+        MAX_NNZ=max(max_nnz, 1), BLOCK_D=_next_pow2(d),
+    )
+    return _flash_combine(m_p, l_p, acc_p, pi)
+
+
+def pck_batched_partials_triton(q, blocks, tq, scale=None):
+    """All cold pages in a **single** launch (M4 §8.5 batched-page item).
+
+    Concatenates the per-page code / CSR / norm arrays and launches one kernel
+    over ``P*H*nsplit`` programs, then flash-combines every (page, split) into
+    one partial per head. Grid parameters (mu, weight) are per page -- pages are
+    independently quantized, and ``zero_point="bias"`` makes ``mu`` position- and
+    length-dependent -- so ``w``/``bias`` are packed ``(P*H, D)``/``(P*H,)`` and
+    indexed per page inside the kernel. Returns one real-space (m, lsum, acc)
+    partial for the whole cold cache; feeds :func:`merge_partials` alongside the
+    hot window exactly like the per-page path, but with a single kernel launch
+    instead of ``P``."""
+    import torch
+
+    if getattr(tq, "_structured", False):
+        raise NotImplementedError("structured rotation not supported by the kernel")
+    if not blocks:
+        raise ValueError("no cold pages")
+    K = _build_kernels()
+    H, d = int(blocks[0].H), int(blocks[0].D)
+    P = len(blocks)
+    qk = _cuda(q, torch.float32).reshape(H, d)
+    cent = _cuda(tq.centroids, torch.float32)
+    pi = _cuda(tq._Pi, torch.float32)
+    grid = _cuda(blocks[0].grid, torch.float32)  # shared: NF4 / arange grid
+    if scale is None:
+        scale = 1.0 / np.sqrt(d)
+
+    # per-page projections + concatenation
+    page_S = [int(b.S) for b in blocks]
+    w_cat = torch.empty((P * H, d), dtype=torch.float32, device="cuda")
+    bias_cat = torch.empty((P * H,), dtype=torch.float32, device="cuda")
+    kc_parts, vc_parts, nv_parts = [], [], []
+    rp_parts, col_parts, dl_parts = [], [], []
+    koff = [0] * P
+    toff = [0] * P
+    k_acc = 0
+    t_acc = 0
+    nnz_acc = 0
+    max_nnz = 0
+    for p, b in enumerate(blocks):
+        weight = _cuda(b.weight, torch.float32)
+        mu = _cuda(b.mu, torch.float32)
+        w_cat[p * H:(p + 1) * H] = qk * weight
+        bias_cat[p * H:(p + 1) * H] = (qk * mu).sum(dim=1)
+        kc_parts.append(_cuda(b.kcodes, torch.uint8).reshape(-1))
+        vc_parts.append(_cuda(b.vcodes, torch.uint8).reshape(-1))
+        nv_parts.append(_cuda(b.norm_v, torch.float32).reshape(-1))
+        rp = _cuda(b.row_ptr, torch.int32)          # (H*S+1,)
+        max_nnz = max(max_nnz, _max_row_nnz(rp))
+        rp_parts.append(rp[:-1] + nnz_acc)          # globalize into shared cols/deltas
+        col_parts.append(_cuda(b.cols, torch.int32))
+        dl_parts.append(_cuda(b.deltas, torch.float32))
+        koff[p] = k_acc
+        toff[p] = t_acc
+        k_acc += H * page_S[p] * d
+        t_acc += H * page_S[p]
+        nnz_acc += int(b.deltas.shape[0]) if hasattr(b.deltas, "shape") else len(
+            b.deltas
+        )
+
+    kcodes = torch.cat(kc_parts).contiguous()
+    vcodes = torch.cat(vc_parts).contiguous()
+    norm_v = torch.cat(nv_parts).contiguous()
+    row_ptr = torch.cat(
+        rp_parts + [torch.tensor([nnz_acc], dtype=torch.int32, device="cuda")]
+    ).contiguous()
+    cols = (
+        torch.cat(col_parts).contiguous()
+        if any(c.numel() for c in col_parts)
+        else torch.zeros(0, dtype=torch.int32, device="cuda")
+    )
+    deltas = (
+        torch.cat(dl_parts).contiguous()
+        if any(dd.numel() for dd in dl_parts)
+        else torch.zeros(0, dtype=torch.float32, device="cuda")
+    )
+    page_S_t = torch.tensor(page_S, dtype=torch.int32, device="cuda")
+    page_koff_t = torch.tensor(koff, dtype=torch.int64, device="cuda")
+    page_toff_t = torch.tensor(toff, dtype=torch.int32, device="cuda")
+    # raw query tiled per page so qk_ptr[ph*D + col] gives q[h, col] for every page
+    qk_cat = qk.repeat(P, 1).contiguous()   # (P*H, D)
+
+    nsplit = _nsplit(max(page_S))
+    m_p = torch.empty((P * H, nsplit), dtype=torch.float32, device="cuda")
+    l_p = torch.empty((P * H, nsplit), dtype=torch.float32, device="cuda")
+    acc_p = torch.empty((P * H, nsplit, d), dtype=torch.float32, device="cuda")
+
+    K["pck_batched"][(P * H * nsplit,)](
+        kcodes, vcodes, w_cat, bias_cat, grid, qk_cat,
+        row_ptr, cols, deltas, norm_v, cent,
+        page_S_t, page_koff_t, page_toff_t,
+        m_p, l_p, acc_p,
+        P, H, d, float(scale), nsplit,
+        MAX_NNZ=max(max_nnz, 1), BLOCK_D=_next_pow2(d),
+    )
+    # combine across pages AND splits per head: reshape (P, H, nsplit)->(H, P*nsplit)
+    m_p = m_p.reshape(P, H, nsplit).permute(1, 0, 2).reshape(H, P * nsplit)
+    l_p = l_p.reshape(P, H, nsplit).permute(1, 0, 2).reshape(H, P * nsplit)
+    acc_p = acc_p.reshape(P, H, nsplit, d).permute(1, 0, 2, 3).reshape(
+        H, P * nsplit, d
+    )
+    return _flash_combine(m_p, l_p, acc_p, pi)
+
+
+def fused_decode_pck_triton(
+    q, key_quantizer, key_container, vcodes, norm_v, tq, return_partials=False
+):
+    """M4 fused decode via Triton (self-contained one-shot, mirrors
+    :func:`turboquant_pro.kv_kernel.fused_decode_pck_cuda`).
+
+    Builds a :class:`~turboquant_pro.kv_fused_pck.PreparedPCKBlock` and runs the
+    Triton kernel. Exact vs the NumPy reference
+    :func:`turboquant_pro.kv_fused_pck.fused_decode_pck` and the CuPy oracle."""
+    import torch
+
+    from .kv_fused_pck import PreparedPCKBlock
+
+    blk = PreparedPCKBlock(key_quantizer, key_container, vcodes, norm_v, xp=np)
+    m, lsum, acc = pck_block_partials_triton(q, blk, tq)
+    if return_partials:
+        return m, lsum, acc
+    return acc / torch.clamp(lsum, min=1e-30)[:, None]
+
+
+def polar_partials_triton(q, kcodes, vcodes, norm_k, norm_v, tq, scale=None):
+    """Cold partials for PolarQuant code-space keys+values via the M2 Triton
+    kernel (port of :func:`turboquant_pro.kv_kernel.fused_decode_cuda`
+    ``method="warp"``). ``q`` (H, d); codes (H, S, d) uint8; norms (H, S).
+    Returns real-space (m, lsum, acc)."""
+    import torch
+
+    if getattr(tq, "_structured", False):
+        raise NotImplementedError("structured rotation not supported by the kernel")
+    K = _build_kernels()
+    q = _cuda(q, torch.float32)
+    H, d = q.shape
+    S = int(np.asarray(kcodes).shape[1]) if not isinstance(
+        kcodes, torch.Tensor
+    ) else int(kcodes.shape[1])
+    cent = _cuda(tq.centroids, torch.float32)
+    pit = _cuda(tq._Pi_T, torch.float32)
+    pi = _cuda(tq._Pi, torch.float32)
+    q_rot = (q @ pit).contiguous()
+    kc = _cuda(kcodes, torch.uint8)
+    vc = _cuda(vcodes, torch.uint8)
+    nk = _cuda(norm_k, torch.float32)
+    nv = _cuda(norm_v, torch.float32)
+    ncent = int(cent.shape[0])
+    if scale is None:
+        scale = 1.0 / np.sqrt(d)
+
+    nsplit = _nsplit(S)
+    m_p = torch.empty((H, nsplit), dtype=torch.float32, device="cuda")
+    l_p = torch.empty((H, nsplit), dtype=torch.float32, device="cuda")
+    acc_p = torch.empty((H, nsplit, d), dtype=torch.float32, device="cuda")
+    K["polar"][(H * nsplit,)](
+        kc, vc, nk, nv, q_rot, cent,
+        m_p, l_p, acc_p,
+        H, S, d, ncent, float(scale), nsplit,
+        BLOCK_D=_next_pow2(d),
+    )
+    return _flash_combine(m_p, l_p, acc_p, pi)

--- a/turboquant_pro/kv_triton.py
+++ b/turboquant_pro/kv_triton.py
@@ -82,9 +82,10 @@ def _nsplit(S: int) -> int:
 
 
 # --------------------------------------------------------------------------
-# Triton kernels are defined inside a lazy builder so the ``@triton.jit``
-# decorator (which imports triton at class-body time) never runs on a
-# CPU-only install. Built once, cached in _K.
+# The @triton.jit kernels live in _triton_kernels (module scope: the compiler
+# resolves `tl` against the kernel's module globals, so it CANNOT be a closure
+# local). That module imports triton at top, so it is imported lazily here --
+# only after has_triton() -- and never on a CPU-only install. Cached in _K.
 # --------------------------------------------------------------------------
 _K: dict = {}
 
@@ -93,181 +94,12 @@ def _build_kernels():
     if _K:
         return _K
     import triton
-    import triton.language as tl
 
-    @triton.jit
-    def _pck_partials_kernel(
-        kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
-        row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
-        m_out_ptr, l_out_ptr, acc_out_ptr,
-        H, S, D, scale, nsplit,
-        MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
-    ):
-        # one program per (head, key-split); mirror of fused_decode_pck
-        pid = tl.program_id(0)
-        h = pid // nsplit
-        split = pid % nsplit
-        if h >= H:
-            return
-        offs = tl.arange(0, BLOCK_D)
-        mask = offs < D
-        w = tl.load(w_ptr + h * D + offs, mask=mask, other=0.0)
-        b = tl.load(bias_ptr + h)
-        chunk = (S + nsplit - 1) // nsplit
-        s0 = split * chunk
-        s1 = tl.minimum(s0 + chunk, S)
+    from . import _triton_kernels as tk
 
-        m = -1e30
-        lsum = 0.0
-        acc = tl.zeros([BLOCK_D], dtype=tl.float32)
-        hS = h * S
-        for s in range(s0, s1):
-            base = (hS + s) * D + offs
-            kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
-            gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
-            partial = tl.sum(w * gk, axis=0)
-            # sparse outlier correction: this token's CSR row (bounded MAX_NNZ)
-            e0 = tl.load(row_ptr_ptr + hS + s)
-            e1 = tl.load(row_ptr_ptr + hS + s + 1)
-            n_e = e1 - e0
-            for e in range(0, MAX_NNZ):
-                valid = e < n_e
-                col = tl.load(cols_ptr + e0 + e, mask=valid, other=0).to(tl.int32)
-                dl = tl.load(deltas_ptr + e0 + e, mask=valid, other=0.0)
-                qv = tl.load(qk_ptr + h * D + col, mask=valid, other=0.0)
-                partial += tl.where(valid, qv * dl, 0.0)
-            score = (partial + b) * scale
-            mn = tl.maximum(m, score)
-            corr = tl.exp(m - mn)
-            p = tl.exp(score - mn)
-            lsum = lsum * corr + p
-            m = mn
-            nv = tl.load(norm_v_ptr + hS + s)
-            vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
-            cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
-            acc = acc * corr + (p * nv) * cv
-
-        po = h * nsplit + split
-        tl.store(m_out_ptr + po, m)
-        tl.store(l_out_ptr + po, lsum)
-        tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
-
-    @triton.jit
-    def _pck_batched_kernel(
-        kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
-        row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
-        page_S_ptr, page_koff_ptr, page_toff_ptr,
-        m_out_ptr, l_out_ptr, acc_out_ptr,
-        P, H, D, scale, nsplit,
-        MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
-    ):
-        # one program per (page, head, key-split): every cold page in one launch
-        pid = tl.program_id(0)
-        hn = H * nsplit
-        p = pid // hn
-        rem = pid % hn
-        h = rem // nsplit
-        split = rem % nsplit
-        if p >= P:
-            return
-        S = tl.load(page_S_ptr + p)
-        koff = tl.load(page_koff_ptr + p)   # element offset into kcodes/vcodes cat
-        toff = tl.load(page_toff_ptr + p)   # token offset (= sum_{q<p} H*S_q)
-        offs = tl.arange(0, BLOCK_D)
-        mask = offs < D
-        # w/bias are per-(page,head): laid out (P*H, D) and (P*H,)
-        ph = p * H + h
-        w = tl.load(w_ptr + ph * D + offs, mask=mask, other=0.0)
-        b = tl.load(bias_ptr + ph)
-        chunk = (S + nsplit - 1) // nsplit
-        s0 = split * chunk
-        s1 = tl.minimum(s0 + chunk, S)
-
-        m = -1e30
-        lsum = 0.0
-        acc = tl.zeros([BLOCK_D], dtype=tl.float32)
-        hS = h * S
-        for s in range(s0, s1):
-            base = koff + (hS + s) * D + offs
-            kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
-            gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
-            partial = tl.sum(w * gk, axis=0)
-            tok = toff + hS + s        # global token index for the shared CSR
-            e0 = tl.load(row_ptr_ptr + tok)
-            e1 = tl.load(row_ptr_ptr + tok + 1)
-            n_e = e1 - e0
-            for e in range(0, MAX_NNZ):
-                valid = e < n_e
-                col = tl.load(cols_ptr + e0 + e, mask=valid, other=0).to(tl.int32)
-                dl = tl.load(deltas_ptr + e0 + e, mask=valid, other=0.0)
-                qv = tl.load(qk_ptr + ph * D + col, mask=valid, other=0.0)
-                partial += tl.where(valid, qv * dl, 0.0)
-            score = (partial + b) * scale
-            mn = tl.maximum(m, score)
-            corr = tl.exp(m - mn)
-            pw = tl.exp(score - mn)
-            lsum = lsum * corr + pw
-            m = mn
-            nv = tl.load(norm_v_ptr + toff + hS + s)
-            vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
-            cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
-            acc = acc * corr + (pw * nv) * cv
-
-        po = (p * H + h) * nsplit + split
-        tl.store(m_out_ptr + po, m)
-        tl.store(l_out_ptr + po, lsum)
-        tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
-
-    @triton.jit
-    def _polar_split_kernel(
-        kcodes_ptr, vcodes_ptr, norm_k_ptr, norm_v_ptr, qrot_ptr, cent_ptr,
-        m_out_ptr, l_out_ptr, acc_out_ptr,
-        H, S, D, ncent, scale, nsplit,
-        BLOCK_D: tl.constexpr,
-    ):
-        # PolarQuant code-space split-K (port of fused_decode_split); keys and
-        # values share the centroid grid, score = norm_k * <q_rot, cent[code]>.
-        pid = tl.program_id(0)
-        h = pid // nsplit
-        split = pid % nsplit
-        if h >= H:
-            return
-        offs = tl.arange(0, BLOCK_D)
-        mask = offs < D
-        qr = tl.load(qrot_ptr + h * D + offs, mask=mask, other=0.0)
-        chunk = (S + nsplit - 1) // nsplit
-        s0 = split * chunk
-        s1 = tl.minimum(s0 + chunk, S)
-
-        m = -1e30
-        lsum = 0.0
-        acc = tl.zeros([BLOCK_D], dtype=tl.float32)
-        hS = h * S
-        for s in range(s0, s1):
-            base = (hS + s) * D + offs
-            kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
-            gk = tl.load(cent_ptr + kc, mask=mask, other=0.0)
-            partial = tl.sum(qr * gk, axis=0)
-            nk = tl.load(norm_k_ptr + hS + s)
-            score = nk * partial * scale
-            mn = tl.maximum(m, score)
-            corr = tl.exp(m - mn)
-            pw = tl.exp(score - mn)
-            lsum = lsum * corr + pw
-            m = mn
-            nv = tl.load(norm_v_ptr + hS + s)
-            vc = tl.load(vcodes_ptr + base, mask=mask, other=0).to(tl.int32)
-            cv = tl.load(cent_ptr + vc, mask=mask, other=0.0)
-            acc = acc * corr + (pw * nv) * cv
-
-        po = h * nsplit + split
-        tl.store(m_out_ptr + po, m)
-        tl.store(l_out_ptr + po, lsum)
-        tl.store(acc_out_ptr + po * D + offs, acc, mask=mask)
-
-    _K["pck"] = _pck_partials_kernel
-    _K["pck_batched"] = _pck_batched_kernel
-    _K["polar"] = _polar_split_kernel
+    _K["pck"] = tk.pck_partials_kernel
+    _K["pck_batched"] = tk.pck_batched_kernel
+    _K["polar"] = tk.polar_split_kernel
     _K["triton"] = triton
     return _K
 


### PR DESCRIPTION
Completes **P5** of the hardware-and-plugins widening plan (`docs/DESIGN_hardware_and_plugins.md` §4.2): a portable Triton port of the two fused compute-on-codes kernels that matter, behind the **same `xp=` seam and prepared-page structs**, so they run on NVIDIA (and ROCm where a target exists) without CuPy. The CuPy RawKernel stays the CUDA reference and the exactness oracle.

## What's here
`turboquant_pro/_triton_kernels.py` (module-scope `@triton.jit`) + `turboquant_pro/kv_triton.py` (host wrappers, lazy gate):
- **M4** `pck_partials_kernel` — per-channel keys + CSR outliers (the shipped key path)
- **Batched-page** `pck_batched_kernel` — every cold page in **one launch** (the deferred §8.5 batched-page item lands in the Triton port per §4.2, "so the effort compounds")
- **M2** `polar_split_kernel` — PolarQuant code-space split-K values
- `BLOCK_D` grid tile removes the warp kernel's `d/32 ≤ 16` register-tiling limit
- `has_triton()` gate; torch/triton imported lazily so **CPU-only installs still import** cleanly
- Wired into `PreparedPCKBlock.partials()` via `_is_torch(xp)`: torch→Triton, cupy→RawKernel (unchanged), numpy→reference — one seam

## Validation — 7/7 exact on NRP L40 (torch 2.4 / triton 3.0)
- **CPU-logic gate** (`test_pck_kernel_logic_numpy`, runs everywhere): replays the kernel's exact control flow (split-K + per-token CSR loop + online softmax + flash-combine) in NumPy and asserts it equals the all-at-once reference. Passes across D=64/96/128 and outlier fractions 0/0.02/0.05 — proves the decomposition before any GPU time.
- **GPU exactness** (`test_triton_*`): per-page, batched-page, and Polar all match the reference to ~fp32 noise. `pytest -q`: **7 passed**.

### Latency (`benchmarks/p5_triton_bench.py`, L40, 8 heads × 128 dim)
| ctx | cold pages | err per-page | err batched | ms per-page | ms batched | batched speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 2,048 | 6 | 7.2e-08 | 8.4e-08 | 3.43 | 2.08 | **1.65×** |
| 8,192 | 30 | 4.5e-08 | 5.2e-08 | 18.09 | 9.32 | **1.94×** |
| 32,768 | 126 | 1.7e-08 | 1.8e-08 | 75.47 | 37.52 | **2.01×** |

The single-launch batched-page kernel widens from 1.65× to ~2× as the cold cache grows. Full record in `benchmarks/RESULTS_p5_triton.md`.

## Remaining (not blocking)
- **CuPy perf-parity column** — the oracle needs CUDA toolkit headers for its own JIT (`cupy-cuda12x[ctk]`); null here, exactness vs the NumPy reference unaffected.
- **A100 perf-parity** — the exit-criterion A100 run; L40 exactness + batched speedup already hold.
- **ROCm** — single-source ready, not validated (Nautilus has no AMD GPUs, §4.5).

## Notes for reviewers — two environment gotchas, both fixed
- Triton JIT needs a host C compiler → use the `-devel` image, not `-runtime`.
- `@triton.jit` kernels must be **module-scope**: Triton resolves `tl` against the kernel's module globals, not closures (a closure-local `tl` → `NameError` at compile time). Hence `_triton_kernels.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)