### PR TITLE
P5: black-format the Triton port files

### DIFF
--- a/benchmarks/p5_triton_bench.py
+++ b/benchmarks/p5_triton_bench.py
@@ -38,8 +38,14 @@ CTXS = [2048, 8192, 32768]
 
 def _build(ctx, seed=0):
     cache = TurboQuantKVCache(
-        head_dim=D, n_heads=H, bits=4, use_gpu=False, seed=seed,
-        per_channel_keys=True, key_nf4_asym=True, key_outlier_frac=0.02,
+        head_dim=D,
+        n_heads=H,
+        bits=4,
+        use_gpu=False,
+        seed=seed,
+        per_channel_keys=True,
+        key_nf4_asym=True,
+        key_outlier_frac=0.02,
         hot_window=512,
     )
     rng = np.random.default_rng(seed)
@@ -100,8 +106,10 @@ def bench_ctx(ctx):
     err_b = float(np.abs(out_b - want).max())
 
     rec = {
-        "ctx": ctx, "pages": len(blocks),
-        "err_per_page": err_pp, "err_batched": err_b,
+        "ctx": ctx,
+        "pages": len(blocks),
+        "err_per_page": err_pp,
+        "err_batched": err_b,
         "ms_per_page": round(_time(per_page), 3),
         "ms_batched": round(_time(batched), 3),
     }
@@ -111,15 +119,23 @@ def bench_ctx(ctx):
         import cupy  # noqa: F401
 
         cg = TurboQuantKVCache(
-            head_dim=D, n_heads=H, bits=4, use_gpu=True, seed=0,
-            per_channel_keys=True, key_nf4_asym=True, key_outlier_frac=0.02,
+            head_dim=D,
+            n_heads=H,
+            bits=4,
+            use_gpu=True,
+            seed=0,
+            per_channel_keys=True,
+            key_nf4_asym=True,
+            key_outlier_frac=0.02,
             hot_window=512,
         )
         rng = np.random.default_rng(0)
         off = rng.uniform(-4, 4, size=(H, D)).astype(np.float32)
         for _ in range(ctx):
-            cg.append((off + rng.standard_normal((H, D))).astype(np.float32),
-                      rng.standard_normal((H, D)).astype(np.float32))
+            cg.append(
+                (off + rng.standard_normal((H, D))).astype(np.float32),
+                rng.standard_normal((H, D)).astype(np.float32),
+            )
         cg.fused_decode(q)  # warm/build prepared pages
         rec["ms_cupy_raw"] = round(_time(lambda: cg.fused_decode(q)), 3)
     except Exception as e:  # noqa: BLE001

--- a/tests/test_kv_triton.py
+++ b/tests/test_kv_triton.py
@@ -28,8 +28,14 @@ from turboquant_pro.kv_triton import _nsplit, has_triton
 def _make_block(H=4, D=64, n_tok=50, outlier=0.02, seed=0):
     """Build one cold PreparedPCKBlock (numpy) + its reference partials."""
     cache = TurboQuantKVCache(
-        head_dim=D, n_heads=H, bits=4, use_gpu=False, seed=seed,
-        per_channel_keys=True, key_nf4_asym=True, key_outlier_frac=outlier,
+        head_dim=D,
+        n_heads=H,
+        bits=4,
+        use_gpu=False,
+        seed=seed,
+        per_channel_keys=True,
+        key_nf4_asym=True,
+        key_outlier_frac=outlier,
         hot_window=4,
     )
     rng = np.random.default_rng(seed)
@@ -51,12 +57,12 @@ def _kernel_sim_pck(blk, q, tq, scale):
     program, per-token CSR row, running (m, lsum, acc))."""
     H, S, D = blk.H, blk.S, blk.D
     q = np.asarray(q, np.float32).reshape(H, D)
-    w = q * np.asarray(blk.weight, np.float32)          # (H, D)
+    w = q * np.asarray(blk.weight, np.float32)  # (H, D)
     bias = (q * np.asarray(blk.mu, np.float32)).sum(1)  # (H,)
     grid = np.asarray(blk.grid, np.float32)
-    kcodes = np.asarray(blk.kcodes)                     # (H, S, D) uint8
+    kcodes = np.asarray(blk.kcodes)  # (H, S, D) uint8
     vcodes = np.asarray(blk.vcodes)
-    norm_v = np.asarray(blk.norm_v, np.float32)         # (H, S)
+    norm_v = np.asarray(blk.norm_v, np.float32)  # (H, S)
     cent = np.asarray(tq.centroids, np.float32)
     pi = np.asarray(tq._Pi, np.float32)
     row_ptr = np.asarray(blk.row_ptr, np.int64)
@@ -103,7 +109,7 @@ def test_pck_kernel_logic_numpy(D, outlier):
     assert len(blocks) >= 1
     tq, scale = cache._tq, 1.0 / np.sqrt(D)
     for blk in blocks:
-        m_ref, l_ref, acc_ref = blk.partials(q, tq, scale)   # numpy reference
+        m_ref, l_ref, acc_ref = blk.partials(q, tq, scale)  # numpy reference
         m_s, l_s, acc_s = _kernel_sim_pck(blk, q, tq, scale)
         assert np.allclose(m_ref, m_s, atol=1e-4), "m mismatch"
         assert np.allclose(l_ref, l_s, rtol=1e-4, atol=1e-4), "lsum mismatch"

--- a/turboquant_pro/_triton_kernels.py
+++ b/turboquant_pro/_triton_kernels.py
@@ -23,11 +23,27 @@ import triton.language as tl
 
 @triton.jit
 def pck_partials_kernel(
-    kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
-    row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
-    m_out_ptr, l_out_ptr, acc_out_ptr,
-    H, S, D, scale, nsplit,
-    MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
+    kcodes_ptr,
+    vcodes_ptr,
+    w_ptr,
+    bias_ptr,
+    grid_ptr,
+    qk_ptr,
+    row_ptr_ptr,
+    cols_ptr,
+    deltas_ptr,
+    norm_v_ptr,
+    cent_ptr,
+    m_out_ptr,
+    l_out_ptr,
+    acc_out_ptr,
+    H,
+    S,
+    D,
+    scale,
+    nsplit,
+    MAX_NNZ: tl.constexpr,
+    BLOCK_D: tl.constexpr,
 ):
     # one program per (head, key-split); mirror of fused_decode_pck
     pid = tl.program_id(0)
@@ -81,12 +97,30 @@ def pck_partials_kernel(
 
 @triton.jit
 def pck_batched_kernel(
-    kcodes_ptr, vcodes_ptr, w_ptr, bias_ptr, grid_ptr, qk_ptr,
-    row_ptr_ptr, cols_ptr, deltas_ptr, norm_v_ptr, cent_ptr,
-    page_S_ptr, page_koff_ptr, page_toff_ptr,
-    m_out_ptr, l_out_ptr, acc_out_ptr,
-    P, H, D, scale, nsplit,
-    MAX_NNZ: tl.constexpr, BLOCK_D: tl.constexpr,
+    kcodes_ptr,
+    vcodes_ptr,
+    w_ptr,
+    bias_ptr,
+    grid_ptr,
+    qk_ptr,
+    row_ptr_ptr,
+    cols_ptr,
+    deltas_ptr,
+    norm_v_ptr,
+    cent_ptr,
+    page_S_ptr,
+    page_koff_ptr,
+    page_toff_ptr,
+    m_out_ptr,
+    l_out_ptr,
+    acc_out_ptr,
+    P,
+    H,
+    D,
+    scale,
+    nsplit,
+    MAX_NNZ: tl.constexpr,
+    BLOCK_D: tl.constexpr,
 ):
     # one program per (page, head, key-split): every cold page in one launch
     pid = tl.program_id(0)
@@ -98,8 +132,8 @@ def pck_batched_kernel(
     if p >= P:
         return
     S = tl.load(page_S_ptr + p)
-    koff = tl.load(page_koff_ptr + p)   # element offset into kcodes/vcodes cat
-    toff = tl.load(page_toff_ptr + p)   # token offset (= sum_{q<p} H*S_q)
+    koff = tl.load(page_koff_ptr + p)  # element offset into kcodes/vcodes cat
+    toff = tl.load(page_toff_ptr + p)  # token offset (= sum_{q<p} H*S_q)
     offs = tl.arange(0, BLOCK_D)
     mask = offs < D
     # w/bias are per-(page,head): laid out (P*H, D) and (P*H,)
@@ -119,7 +153,7 @@ def pck_batched_kernel(
         kc = tl.load(kcodes_ptr + base, mask=mask, other=0).to(tl.int32)
         gk = tl.load(grid_ptr + kc, mask=mask, other=0.0)
         partial = tl.sum(w * gk, axis=0)
-        tok = toff + hS + s        # global token index for the shared CSR
+        tok = toff + hS + s  # global token index for the shared CSR
         e0 = tl.load(row_ptr_ptr + tok)
         e1 = tl.load(row_ptr_ptr + tok + 1)
         n_e = e1 - e0
@@ -148,9 +182,21 @@ def pck_batched_kernel(
 
 @triton.jit
 def polar_split_kernel(
-    kcodes_ptr, vcodes_ptr, norm_k_ptr, norm_v_ptr, qrot_ptr, cent_ptr,
-    m_out_ptr, l_out_ptr, acc_out_ptr,
-    H, S, D, ncent, scale, nsplit,
+    kcodes_ptr,
+    vcodes_ptr,
+    norm_k_ptr,
+    norm_v_ptr,
+    qrot_ptr,
+    cent_ptr,
+    m_out_ptr,
+    l_out_ptr,
+    acc_out_ptr,
+    H,
+    S,
+    D,
+    ncent,
+    scale,
+    nsplit,
     BLOCK_D: tl.constexpr,
 ):
     # PolarQuant code-space split-K (port of fused_decode_split); keys and

--- a/turboquant_pro/kv_triton.py
+++ b/turboquant_pro/kv_triton.py
@@ -124,8 +124,10 @@ def _cuda(t, dtype=None):
 def _max_row_nnz(row_ptr) -> int:
     import torch
 
-    rp = row_ptr if isinstance(row_ptr, torch.Tensor) else torch.as_tensor(
-        np.asarray(row_ptr)
+    rp = (
+        row_ptr
+        if isinstance(row_ptr, torch.Tensor)
+        else torch.as_tensor(np.asarray(row_ptr))
     )
     if rp.numel() <= 1:
         return 0
@@ -169,7 +171,7 @@ def pck_block_partials_triton(q, blk, tq, scale=None):
     vcodes = _cuda(blk.vcodes, torch.uint8)
     norm_v = _cuda(blk.norm_v, torch.float32)
     row_ptr = _cuda(blk.row_ptr, torch.int32)
-    cols = _cuda(blk.cols, torch.int32)   # uint16 -> int32 for gather
+    cols = _cuda(blk.cols, torch.int32)  # uint16 -> int32 for gather
     deltas = _cuda(blk.deltas, torch.float32)
     if scale is None:
         scale = 1.0 / np.sqrt(d)
@@ -181,11 +183,27 @@ def pck_block_partials_triton(q, blk, tq, scale=None):
     acc_p = torch.empty((H, nsplit, d), dtype=torch.float32, device="cuda")
 
     K["pck"][(H * nsplit,)](
-        kcodes, vcodes, w, bias, grid, qk,
-        row_ptr, cols, deltas, norm_v, cent,
-        m_p, l_p, acc_p,
-        H, S, d, float(scale), nsplit,
-        MAX_NNZ=max(max_nnz, 1), BLOCK_D=_next_pow2(d),
+        kcodes,
+        vcodes,
+        w,
+        bias,
+        grid,
+        qk,
+        row_ptr,
+        cols,
+        deltas,
+        norm_v,
+        cent,
+        m_p,
+        l_p,
+        acc_p,
+        H,
+        S,
+        d,
+        float(scale),
+        nsplit,
+        MAX_NNZ=max(max_nnz, 1),
+        BLOCK_D=_next_pow2(d),
     )
     return _flash_combine(m_p, l_p, acc_p, pi)
 
@@ -233,22 +251,22 @@ def pck_batched_partials_triton(q, blocks, tq, scale=None):
     for p, b in enumerate(blocks):
         weight = _cuda(b.weight, torch.float32)
         mu = _cuda(b.mu, torch.float32)
-        w_cat[p * H:(p + 1) * H] = qk * weight
-        bias_cat[p * H:(p + 1) * H] = (qk * mu).sum(dim=1)
+        w_cat[p * H : (p + 1) * H] = qk * weight
+        bias_cat[p * H : (p + 1) * H] = (qk * mu).sum(dim=1)
         kc_parts.append(_cuda(b.kcodes, torch.uint8).reshape(-1))
         vc_parts.append(_cuda(b.vcodes, torch.uint8).reshape(-1))
         nv_parts.append(_cuda(b.norm_v, torch.float32).reshape(-1))
-        rp = _cuda(b.row_ptr, torch.int32)          # (H*S+1,)
+        rp = _cuda(b.row_ptr, torch.int32)  # (H*S+1,)
         max_nnz = max(max_nnz, _max_row_nnz(rp))
-        rp_parts.append(rp[:-1] + nnz_acc)          # globalize into shared cols/deltas
+        rp_parts.append(rp[:-1] + nnz_acc)  # globalize into shared cols/deltas
         col_parts.append(_cuda(b.cols, torch.int32))
         dl_parts.append(_cuda(b.deltas, torch.float32))
         koff[p] = k_acc
         toff[p] = t_acc
         k_acc += H * page_S[p] * d
         t_acc += H * page_S[p]
-        nnz_acc += int(b.deltas.shape[0]) if hasattr(b.deltas, "shape") else len(
-            b.deltas
+        nnz_acc += (
+            int(b.deltas.shape[0]) if hasattr(b.deltas, "shape") else len(b.deltas)
         )
 
     kcodes = torch.cat(kc_parts).contiguous()
@@ -271,7 +289,7 @@ def pck_batched_partials_triton(q, blocks, tq, scale=None):
     page_koff_t = torch.tensor(koff, dtype=torch.int64, device="cuda")
     page_toff_t = torch.tensor(toff, dtype=torch.int32, device="cuda")
     # raw query tiled per page so qk_ptr[ph*D + col] gives q[h, col] for every page
-    qk_cat = qk.repeat(P, 1).contiguous()   # (P*H, D)
+    qk_cat = qk.repeat(P, 1).contiguous()  # (P*H, D)
 
     nsplit = _nsplit(max(page_S))
     m_p = torch.empty((P * H, nsplit), dtype=torch.float32, device="cuda")
@@ -279,19 +297,35 @@ def pck_batched_partials_triton(q, blocks, tq, scale=None):
     acc_p = torch.empty((P * H, nsplit, d), dtype=torch.float32, device="cuda")
 
     K["pck_batched"][(P * H * nsplit,)](
-        kcodes, vcodes, w_cat, bias_cat, grid, qk_cat,
-        row_ptr, cols, deltas, norm_v, cent,
-        page_S_t, page_koff_t, page_toff_t,
-        m_p, l_p, acc_p,
-        P, H, d, float(scale), nsplit,
-        MAX_NNZ=max(max_nnz, 1), BLOCK_D=_next_pow2(d),
+        kcodes,
+        vcodes,
+        w_cat,
+        bias_cat,
+        grid,
+        qk_cat,
+        row_ptr,
+        cols,
+        deltas,
+        norm_v,
+        cent,
+        page_S_t,
+        page_koff_t,
+        page_toff_t,
+        m_p,
+        l_p,
+        acc_p,
+        P,
+        H,
+        d,
+        float(scale),
+        nsplit,
+        MAX_NNZ=max(max_nnz, 1),
+        BLOCK_D=_next_pow2(d),
     )
     # combine across pages AND splits per head: reshape (P, H, nsplit)->(H, P*nsplit)
     m_p = m_p.reshape(P, H, nsplit).permute(1, 0, 2).reshape(H, P * nsplit)
     l_p = l_p.reshape(P, H, nsplit).permute(1, 0, 2).reshape(H, P * nsplit)
-    acc_p = acc_p.reshape(P, H, nsplit, d).permute(1, 0, 2, 3).reshape(
-        H, P * nsplit, d
-    )
+    acc_p = acc_p.reshape(P, H, nsplit, d).permute(1, 0, 2, 3).reshape(H, P * nsplit, d)
     return _flash_combine(m_p, l_p, acc_p, pi)
 
 
@@ -327,9 +361,11 @@ def polar_partials_triton(q, kcodes, vcodes, norm_k, norm_v, tq, scale=None):
     K = _build_kernels()
     q = _cuda(q, torch.float32)
     H, d = q.shape
-    S = int(np.asarray(kcodes).shape[1]) if not isinstance(
-        kcodes, torch.Tensor
-    ) else int(kcodes.shape[1])
+    S = (
+        int(np.asarray(kcodes).shape[1])
+        if not isinstance(kcodes, torch.Tensor)
+        else int(kcodes.shape[1])
+    )
     cent = _cuda(tq.centroids, torch.float32)
     pit = _cuda(tq._Pi_T, torch.float32)
     pi = _cuda(tq._Pi, torch.float32)
@@ -347,9 +383,21 @@ def polar_partials_triton(q, kcodes, vcodes, norm_k, norm_v, tq, scale=None):
     l_p = torch.empty((H, nsplit), dtype=torch.float32, device="cuda")
     acc_p = torch.empty((H, nsplit, d), dtype=torch.float32, device="cuda")
     K["polar"][(H * nsplit,)](
-        kc, vc, nk, nv, q_rot, cent,
-        m_p, l_p, acc_p,
-        H, S, d, ncent, float(scale), nsplit,
+        kc,
+        vc,
+        nk,
+        nv,
+        q_rot,
+        cent,
+        m_p,
+        l_p,
+        acc_p,
+        H,
+        S,
+        d,
+        ncent,
+        float(scale),
+        nsplit,
         BLOCK_D=_next_pow2(d),
     )
     return _flash_combine(m_p, l_p, acc_p, pi)


### PR DESCRIPTION
Follow-up to #133: the merged P5 files pass ruff but not `black --check` (compact multi-arg calls). Pure formatting, no behavior change. Fixes the red format check on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)