### PR TITLE
coverage: T4 Turing soak — 216,237 cases, 0 failures

### DIFF
--- a/benchmarks/RESULTS_fuzz_coverage.md
+++ b/benchmarks/RESULTS_fuzz_coverage.md
@@ -10,6 +10,7 @@ where CuPy exists, the M2/M4 CUDA kernels), and invalid-shape-must-raise.
 | host | arch | budget | cases | failures |
 |---|---|---|---:|---:|
 | lightning H100 80GB | Hopper | 30 min | **71,060** | **0** |
+| lightning T4 16GB | Turing | soak | **216,237** | **0** |
 
 (Early in the same session, 10/5,725 flags traced to the fuzzer's own
 absolute tolerance at the 100× input-scale extreme — actual disagreement
@@ -17,5 +18,9 @@ absolute tolerance at the 100× input-scale extreme — actual disagreement
 since. Formats covered: per_channel, polar, bnb_nf4, bnb_llm_int8, fp8_kv,
 nvfp4_kv, gptq, awq.)
 
-Pending rows: T4 (Turing) soak, L40S + CuPy kernel-path leg, H200
+The Turing soak (216,237 cases, 0 failures) is the largest single-arch
+sweep to date — same eight formats, same scale-aware invariants, no CUDA
+kernel leg (T4 has no CuPy install here, so the CPU dispatch path only).
+
+Pending rows: L40S + CuPy kernel-path leg (`tqp-cupy-fuzz`, running), H200
 long-context. Not reachable and stated plainly: MPS, ROCm, Blackwell-native.


### PR DESCRIPTION
Adds the T4 (Turing) row to the randomized-coverage ledger: 216,237 cases fuzzed, 0 failures — the largest single-arch sweep to date (CPU dispatch path, all eight plugin formats, scale-aware invariants). Trims T4 from the pending list; L40S CuPy-kernel leg and H200 long-context remain.

Docs-only (`benchmarks/RESULTS_fuzz_coverage.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)