### PR TITLE
docs: master-vs-PyPI release-boundary banner for tqp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Main public benchmark notebook: compatible with 1.4.x
 
 Package [`v1.7.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.7.0) is the current release; the DOI-archived core-results artifact is [`v1.4.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.4.0) · DOI [10.5281/zenodo.20660087](https://doi.org/10.5281/zenodo.20660087).
 
+> ⚠️ **The `tqp` CLI and the certification platform are 1.8.0 (master), not yet on PyPI.** 1.7.0 is the current *library* release; the `tqp` console script, the `trace → plan → compress → certify → replay → monitor` pipeline, and the persisted-index/plugin certification lifecycle land in **1.8.0**. Until it's released, `pip install turboquant-pro` gives you the library but **not** `tqp` — install from `master` for the CLI: `pip install "turboquant-pro[torch] @ git+https://github.com/ahb-sjsu/turboquant-pro"` (see [`docs/CLI.md`](docs/CLI.md#install)).
+
 ### Not to be confused with
 `turboquant-pro` is distinct from the similarly-named `turboquant`, `pyturboquant`, `turboquant-ml`, `turboquant-py`, `turboquant_plus`, and **vLLM's own TurboQuant integration**.
 
@@ -87,6 +89,8 @@ In particular, it is **distinct from the `turboquant` package focused on Hugging
 Full release history is in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Installation
+
+> The commands below install the **library**. The `tqp` CLI and certification platform ship in **1.8.0** — until it's on PyPI, add `tqp` from master: `pip install "turboquant-pro[torch] @ git+https://github.com/ahb-sjsu/turboquant-pro"`.
 
 ```bash
 pip install turboquant-pro

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,8 +19,20 @@ are pure stdlib + numpy; `tqp trace` additionally needs `[torch]` + transformers
 
 ## Install
 
+> ⚠️ **Release boundary — `tqp` ships in 1.8.0 (master), not yet on PyPI.** The
+> latest PyPI release is **1.7.0**, which does **not** include the `tqp` console
+> script or the certification platform. Until 1.8.0 is released, install from
+> `master` to get `tqp`:
+>
+> ```bash
+> pip install "turboquant-pro[torch] @ git+https://github.com/ahb-sjsu/turboquant-pro"
+> ```
+>
+> Once 1.8.0 is on PyPI, `pip install turboquant-pro` will give you `tqp` directly
+> — the commands below assume 1.8.0 / master.
+
 ```bash
-pip install turboquant-pro          # gives you `tqp`
+pip install turboquant-pro          # gives you `tqp` (1.8.0+; from master until released)
 pip install 'turboquant-pro[torch]' transformers   # additionally enables `tqp trace`
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # TurboQuant Pro — documentation
 
+> ⚠️ **`tqp` and the certification platform are 1.8.0 (master), not yet on PyPI** (latest release: 1.7.0). Every `tqp …` command in these docs and guides assumes 1.8.0 — until it's released, install the CLI from master: `pip install "turboquant-pro[torch] @ git+https://github.com/ahb-sjsu/turboquant-pro"`. See [`CLI.md`](CLI.md#install).
+
 TurboQuant Pro is embedding and KV-cache compression built around one idea: **the
 right way to compress a tensor is dictated by what its consumer does with it**, and
 acceptance is measured on **that consumer's metric** — recall, a rank certificate,

--- a/docs/guides/user_guide.md
+++ b/docs/guides/user_guide.md
@@ -7,6 +7,8 @@ This is the shortest path from a corpus of embeddings to a compressed index you 
 pip install turboquant-pro
 ```
 
+> This library workflow runs on the current 1.7.0 PyPI release. The **`tqp` CLI** used in the [certification](certification.md) and [claim-replay](claim_replay.md) guides ships in **1.8.0** — until it's released, install it from master: `pip install "turboquant-pro[torch] @ git+https://github.com/ahb-sjsu/turboquant-pro"`.
+
 ## 1. Compress and search (the library)
 
 `PCAMatryoshka` reduces dimension by reordered PCA; `.with_quantizer(bits=...)` adds


### PR DESCRIPTION
Release blocker #1 from the 1.8.0 review. `docs/CLI.md` and the README install block promised `pip install turboquant-pro` → `tqp`, which is **false on today's PyPI (1.7.0)** — 1.7.0 ships the library, not the `tqp` CLI / certification platform (those are 1.8.0/master).

Adds a consistent master-install banner to: `docs/CLI.md` (install), README (version + installation), the docs hub (`docs/README.md`), and the entry `user_guide.md` — all pointing at `pip install "turboquant-pro[torch] @ git+…"` and clarifying the 1.8.0 boundary. Leaves the 1.7.0 library-install commands intact where they're correct. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)