### PR TITLE
feat(cli): tqp verify — schema + recompute of a certificate.json

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,7 +7,7 @@ are pure stdlib + numpy; `tqp trace` additionally needs `[torch]` + transformers
 > **Status:** Phases 1–4 of [`docs/turboquant_pro_next_level_roadmap.md`](turboquant_pro_next_level_roadmap.md).
 > The full pipeline `trace → plan → compress → certify → replay → monitor` is
 > live: `version`, `plugin list`/`conformance`, `trace`, `probe`, `plan`,
-> `certify`, `replay`, `monitor`. No stubs remain.
+> `certify`, `verify`, `replay`, `monitor`, `index`. No stubs remain.
 >
 > **Coherence rule.** Every command's acceptance signal is **rank fidelity /
 > the (A2) consumer metric / a distribution-free certificate** — never
@@ -162,6 +162,31 @@ metric=cosine  anchors=200  pairs=19900
 A vacuous certificate (`tau_floor <= 0`, seen on distance-concentrated corpora)
 is itself the signal: single-stage rank fidelity can't be certified, so exact
 reranking is mandatory.
+
+### `tqp verify CERTIFICATE.json [--original PATH --reconstructed PATH] [--atol A] [--rtol R] [--out FILE] [--format text|json]`
+Checks a `certificate.json` **that someone else emitted** — the trust primitive
+`certify` was missing. Two layers:
+
+- **Schema / self-consistency (always):** the schema and version are recognized,
+  the required fields are present, `passed` is a boolean, and the recorded rank
+  statistics are inside their valid ranges (`tau_floor`, `spearman_floor` in
+  `[-1, 1]`; `kappa >= 0`; `n_pairs` a positive int). Runs offline, no data
+  needed — catches a truncated or hand-edited certificate.
+- **Independent recompute (when `--original`/`--reconstructed` are given):**
+  re-hashes the two `.npy` inputs and compares to the recorded `sha256`, then
+  **re-runs the certification with the certificate's own params** (metric,
+  anchors, seed) and confirms the recomputed `kappa`/`mu_hat`/`tau_floor`/
+  `spearman_floor` match the recorded values within `--atol`/`--rtol`. This is
+  the reproduction check: same inputs + same params must reproduce the claim.
+
+**Exit code is a gate:** 0 when verified, 1 when the schema is malformed *or* a
+recompute mismatches (bad hash or drifted floor), 2 on a read error. `certify`
+writes certificates; `verify` is how a third party trusts one.
+
+```bash
+tqp verify certificate.json                                   # schema/self-consistency only
+tqp verify certificate.json --original emb.npy --reconstructed emb_q.npy   # full reproduction
+```
 
 ### `tqp plan embeddings --embeddings PATH [--target STR] [--max-bytes-per-vector N] [--sample N] [--seed N] [--out FILE] [--format json|text]`
 Task-aware embedding-compression planner. Runs `auto_compress` to sweep the

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -1,0 +1,95 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""`tqp verify` — schema/self-consistency + independent recompute of a
+certificate.json emitted by `tqp certify`. Covers the happy path (schema-only
+and recompute), and the three ways a certificate can fail to verify: a tampered
+recorded floor, an input-hash mismatch, and a malformed schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import numpy as np
+
+from turboquant_pro import cli
+
+
+def _ns(**kw):
+    return argparse.Namespace(**kw)
+
+
+def _make_cert(tmp_path, seed=0, noise=0.01):
+    rng = np.random.default_rng(seed)
+    orig = rng.standard_normal((80, 24)).astype(np.float32)
+    recon = (orig + noise * rng.standard_normal((80, 24))).astype(np.float32)
+    op, rp, certp = tmp_path / "o.npy", tmp_path / "r.npy", tmp_path / "cert.json"
+    np.save(op, orig)
+    np.save(rp, recon)
+    cli._cmd_certify(
+        _ns(
+            original=str(op),
+            reconstructed=str(rp),
+            metric="cosine",
+            anchors=50,
+            seed=0,
+            min_tau=None,
+            out=str(certp),
+            format="json",
+        )
+    )
+    assert certp.exists()
+    return op, rp, certp
+
+
+def _verify(certp, original=None, reconstructed=None):
+    return cli._cmd_verify(
+        _ns(
+            certificate=str(certp),
+            original=str(original) if original else None,
+            reconstructed=str(reconstructed) if reconstructed else None,
+            atol=1e-6,
+            rtol=1e-4,
+            out=None,
+            format="text",
+        )
+    )
+
+
+def test_verify_schema_only_ok(tmp_path):
+    _, _, certp = _make_cert(tmp_path)
+    assert _verify(certp) == 0
+
+
+def test_verify_recompute_matches(tmp_path):
+    op, rp, certp = _make_cert(tmp_path)
+    assert _verify(certp, op, rp) == 0
+
+
+def test_verify_detects_tampered_floor(tmp_path):
+    op, rp, certp = _make_cert(tmp_path)
+    doc = json.loads(certp.read_text())
+    doc["certificate"]["tau_floor"] = -0.5  # bogus but in-range, so schema still OK
+    certp.write_text(json.dumps(doc))
+    assert _verify(certp, op, rp) == 1  # recompute exposes the mismatch
+
+
+def test_verify_detects_hash_mismatch(tmp_path):
+    op, rp, certp = _make_cert(tmp_path)
+    other = tmp_path / "other.npy"
+    np.save(
+        other, np.random.default_rng(9).standard_normal((80, 24)).astype(np.float32)
+    )
+    assert _verify(certp, other, rp) == 1  # inputs don't match recorded hashes
+
+
+def test_verify_bad_schema(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"schema": "nope", "certificate": {}}))
+    assert _verify(bad) == 1
+
+
+def test_verify_missing_file(tmp_path):
+    assert _verify(tmp_path / "nope.json") == 2  # IO error -> exit 2

--- a/turboquant_pro/cli.py
+++ b/turboquant_pro/cli.py
@@ -466,6 +466,190 @@ def _cmd_certify(args: argparse.Namespace) -> int:
     return 0 if passed else 1
 
 
+def _verify_schema(doc: dict) -> list[str]:
+    """Structural + self-consistency checks on a certificate doc (no data needed).
+
+    Returns a list of human-readable problems; empty means the certificate is
+    well-formed and internally sane (recognized schema, required fields present,
+    rank statistics inside their valid ranges)."""
+    import math
+
+    problems: list[str] = []
+    schema = doc.get("schema")
+    if schema not in (
+        "turboquant-pro/rank-certificate",
+        "turboquant-pro/index-certificate",
+    ):
+        problems.append(f"unrecognized schema {schema!r}")
+    if doc.get("schema_version") != 1:
+        problems.append(f"unsupported schema_version {doc.get('schema_version')!r}")
+    for key in ("tool_version", "params", "certificate", "interpretation", "passed"):
+        if key not in doc:
+            problems.append(f"missing top-level key {key!r}")
+    if not isinstance(doc.get("passed"), bool):
+        problems.append("`passed` is not a boolean")
+
+    def _num(x) -> bool:
+        return isinstance(x, (int, float)) and math.isfinite(x)
+
+    cert = doc.get("certificate") or {}
+    for key in ("kappa", "mu_hat", "tau_floor", "spearman_floor", "n_pairs"):
+        if key not in cert:
+            problems.append(f"certificate missing {key!r}")
+    for key in ("tau_floor", "spearman_floor"):
+        v = cert.get(key)
+        if v is not None and not (_num(v) and -1.0 - 1e-9 <= v <= 1.0 + 1e-9):
+            problems.append(f"certificate.{key}={v!r} outside [-1, 1]")
+    if "kappa" in cert and not (_num(cert["kappa"]) and cert["kappa"] >= -1e-9):
+        problems.append(f"certificate.kappa={cert['kappa']!r} negative or non-finite")
+    npairs = cert.get("n_pairs")
+    if npairs is not None and not (isinstance(npairs, int) and npairs > 0):
+        problems.append(f"certificate.n_pairs={npairs!r} is not a positive int")
+    return problems
+
+
+def _verify_recompute(doc: dict, args: argparse.Namespace) -> dict:
+    """Recompute the rank certificate from ``--original``/``--reconstructed`` and
+    compare to the recorded hashes + floors. Independent reproduction."""
+    import numpy as np
+
+    from turboquant_pro import certificate_from_embeddings
+
+    if doc.get("schema") != "turboquant-pro/rank-certificate":
+        return {
+            "skipped": True,
+            "error": "recompute (--original/--reconstructed) is only defined for "
+            f"rank certificates; this is {doc.get('schema')!r}",
+        }
+    try:
+        orig = np.asarray(np.load(args.original))
+        recon = np.asarray(np.load(args.reconstructed))
+    except Exception as e:  # noqa: BLE001
+        return {"skipped": True, "error": f"cannot load inputs: {e}"}
+    if orig.ndim > 2:
+        orig = orig.reshape(-1, orig.shape[-1])
+        recon = recon.reshape(-1, recon.shape[-1])
+    if orig.shape != recon.shape or orig.ndim != 2:
+        return {"skipped": True, "error": f"bad/mismatched input shapes {orig.shape}"}
+
+    inp = doc.get("inputs", {})
+    hashes = {
+        "original": (
+            _sha256_array(orig),
+            (inp.get("original") or {}).get("sha256"),
+        ),
+        "reconstructed": (
+            _sha256_array(recon),
+            (inp.get("reconstructed") or {}).get("sha256"),
+        ),
+    }
+    hash_match = {k: (h == rec) for k, (h, rec) in hashes.items()}
+    hashes_ok = all(rec is not None and h == rec for h, rec in hashes.values())
+
+    p = doc.get("params", {})
+    cert = certificate_from_embeddings(
+        orig,
+        recon,
+        n_anchors=int(p.get("n_anchors", 200)),
+        metric=p.get("metric", "cosine"),
+        seed=int(p.get("seed", 0)),
+    )
+    cvals = cert.as_dict()
+    recorded = doc.get("certificate", {})
+    fields = ("kappa", "mu_hat", "tau_floor", "spearman_floor")
+    deltas, values_ok = {}, True
+    for k in fields:
+        rv, gv = recorded.get(k), cvals.get(k)
+        if rv is None or gv is None:
+            continue
+        d = abs(float(gv) - float(rv))
+        deltas[k] = d
+        if d > args.atol + args.rtol * abs(float(rv)):
+            values_ok = False
+    return {
+        "skipped": False,
+        "hash_match": hash_match,
+        "hashes_ok": hashes_ok,
+        "recomputed": {k: cvals.get(k) for k in fields},
+        "recorded": {k: recorded.get(k) for k in fields},
+        "abs_delta": deltas,
+        "tol": {"atol": args.atol, "rtol": args.rtol},
+        "match": bool(hashes_ok and values_ok),
+    }
+
+
+def _verify_summary(r: dict) -> str:
+    c = r["checks"]
+    cert = r["certificate"]
+    lines = [
+        f"# tqp verify  {cert['path']}  (schema={cert['schema']})",
+        f"  schema/self-consistency: {'OK' if c['schema_ok'] else 'FAILED'}",
+    ]
+    lines += [f"    - {p}" for p in c.get("schema_problems", [])]
+    rc = c.get("recompute")
+    if rc is not None:
+        if rc.get("skipped"):
+            lines.append(f"  recompute: skipped — {rc.get('error')}")
+        else:
+            lines.append(
+                f"  recompute vs recorded: "
+                f"{'MATCH' if rc['match'] else 'MISMATCH'} "
+                f"(input hashes {'ok' if rc['hashes_ok'] else 'DIFFER'})"
+            )
+            for k, d in rc.get("abs_delta", {}).items():
+                lines.append(f"    {k}: |Δ|={d:.2e}")
+    lines.append(f"=> {'VERIFIED' if r['verified'] else 'NOT VERIFIED'}")
+    return "\n".join(lines)
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    import json
+
+    from turboquant_pro import __version__
+
+    try:
+        with open(args.certificate, encoding="utf-8") as f:
+            doc = json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"verify: cannot read {args.certificate!r}: {e}", file=sys.stderr)
+        return 2
+
+    if bool(args.original) != bool(args.reconstructed):
+        print(
+            "verify: --original and --reconstructed must be given together to "
+            "recompute; ignoring the lone one and checking schema only",
+            file=sys.stderr,
+        )
+
+    problems = _verify_schema(doc)
+    checks: dict = {"schema_ok": not problems, "schema_problems": problems}
+    recompute = None
+    if args.original and args.reconstructed:
+        recompute = _verify_recompute(doc, args)
+        checks["recompute"] = recompute
+
+    match_ok = (
+        recompute is None or recompute.get("skipped") or recompute.get("match") is True
+    )
+    verified = (not problems) and match_ok
+    result = {
+        "schema": "turboquant-pro/verification",
+        "schema_version": 1,
+        "tool_version": __version__,
+        "created_utc": _now_utc(),
+        "certificate": {
+            "path": args.certificate,
+            "schema": doc.get("schema"),
+            "tool_version": doc.get("tool_version"),
+        },
+        "checks": checks,
+        "verified": verified,
+    }
+    if not _emit_doc(result, args.out, args.format, _verify_summary(result)):
+        return 2
+    return 0 if verified else 1
+
+
 def _now_utc() -> str:
     import datetime
 
@@ -1238,6 +1422,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="stdout format when --out is not given (default json)",
     )
     ce.set_defaults(func=_cmd_certify)
+
+    vf = sub.add_parser(
+        "verify",
+        help="verify a certificate.json — schema/self-consistency always, plus "
+        "recompute vs inputs when --original/--reconstructed are given",
+    )
+    vf.add_argument(
+        "certificate", help="path to a certificate.json (from `tqp certify`)"
+    )
+    vf.add_argument(
+        "--original", help=".npy of original embeddings (enables recompute)"
+    )
+    vf.add_argument(
+        "--reconstructed", help=".npy of reconstructed embeddings (enables recompute)"
+    )
+    vf.add_argument(
+        "--atol", type=float, default=1e-6, help="abs tolerance on recomputed floors"
+    )
+    vf.add_argument(
+        "--rtol", type=float, default=1e-4, help="rel tolerance on recomputed floors"
+    )
+    vf.add_argument("--out", help="write the verification report here")
+    vf.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="stdout format when --out is not given (default text)",
+    )
+    vf.set_defaults(func=_cmd_verify)
 
     # plan (nested) — task-aware recipe planner
     pn = sub.add_parser("plan", help="task-aware recipe planner (embeddings | kv)")


### PR DESCRIPTION
Release blocker from the 1.8.0 review: `certify`/`index certify` **emit** certificates but nothing **re-checks** one. `tqp verify` is the missing trust primitive.

Two layers (the semantics you picked — schema + recompute):
- **Schema / self-consistency (always, offline):** recognized schema+version, required fields, `passed` is bool, rank stats in range (`tau_floor`/`spearman_floor` ∈ [-1,1], `kappa ≥ 0`, `n_pairs > 0`). Catches truncated/hand-edited certs.
- **Independent recompute (`--original`/`--reconstructed`):** re-hash the inputs vs recorded `sha256`, re-run `certificate_from_embeddings` with the certificate's **own** params, confirm the recomputed `kappa`/`mu_hat`/`tau_floor`/`spearman_floor` match within `--atol`/`--rtol`. Same inputs + params must reproduce the claim.

Exit **0** verified / **1** malformed-or-mismatch / **2** read error. **6 tests** (schema-only, recompute-match, tampered floor, hash mismatch, bad schema, missing file), ruff+black clean, documented in `docs/CLI.md`.

`certify` writes certificates; `verify` is how a third party trusts one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)