### PR TITLE
docs: reconcile stability tiers (README ↔ api-stability.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ Package [`v1.7.0`](https://github.com/ahb-sjsu/turboquant-pro/releases/tag/v1.7.
 
 In particular, it is **distinct from the `turboquant` package focused on HuggingFace KV-cache compression** (an implementation of the Google/ICLR *TurboQuant* KV-cache algorithm). The original TurboQuant paper ([Zandieh et al., ICLR 2026](https://arxiv.org/abs/2504.19874)) is about *online vector quantization with near-optimal distortion rate*; here that quantizer is **one component** of a broader, retrieval-first toolkit — the headline contribution is PCA-Matryoshka compressed embedding retrieval, with KV-cache and systems integrations alongside it.
 
-### API stability (summary — full table in [`docs/api-stability.md`](docs/api-stability.md))
+### API stability (summary — full table in [`docs/api-stability.md`](docs/api-stability.md), the source of truth)
 | Tier | Components |
 |---|---|
 | **Stable** | `PCAMatryoshka`, embedding compression pipeline, basic `TurboQuantKV`, TQE1 format |
-| **Beta** | `ADCIndex`, `TurboQuantKVCache`, FAISS / pgvector wrappers |
-| **Experimental** | CUDA fused decode, vLLM manager, model-weight compressor, PostgreSQL extension, NATS transport |
+| **Beta** | `ADCIndex`, `TurboQuantKVCache`, the **rank certificate** (`tqp certify`/`verify`), the **(A2) probe + quality monitor**, the **`tqp index`** persisted-index lifecycle, the runtime safe-fallback policy, FAISS / pgvector wrappers |
+| **Experimental** | quantizer **plugin registry + conformance kit** (eligible to promote), CUDA fused decode, vLLM manager, model-weight compressor, PostgreSQL extension, NATS transport |
+
+The `tqp` CLI and the certification platform ship in **1.8.0** (see the release-boundary note above); the tiers here describe the underlying APIs those commands surface.
 
 > **Evaluate on the metric that matters.** Cosine similarity to the original vector is *not* a reliable proxy for downstream quality — for retrieval it diverges from recall at high compression, and for KV-cache **keys** it is actively misleading (see [v1.2.0 below](#highlights)). Always measure recall (retrieval) or perplexity (generation).
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -6,6 +6,13 @@ major version, covered by tests, changes go through deprecation; **Beta** = usab
 but the API may change in a minor release; **Experimental** = research/preview, may change or
 be removed without notice, may require optional dependencies or specific hardware.
 
+> **Release boundary.** The `tqp` CLI and the certification platform (`tqp
+> certify`/`verify`, the `tqp index` lifecycle, the plugin registry) ship in
+> **1.8.0**, which is not yet on PyPI (latest release: 1.7.0 — the library only).
+> Until 1.8.0 is out, install from master for the CLI (see
+> [`CLI.md`](CLI.md#install)). The tiers below describe the underlying APIs
+> regardless of which release exposes them.
+
 ## Stable
 - **`PCAMatryoshka`** — PCA-reordered dimension reduction.
 - **Embedding compression** — the PCA + TurboQuant scalar-quantization pipeline and its
@@ -19,7 +26,8 @@ be removed without notice, may require optional dependencies or specific hardwar
 - **`PerChannelKV` zero-point modes** (`"sparse"` / `"bias"`) — LongBench-validated; the
   container metadata fields (`zp_mode`, `rope_theta`, `position_start`) may evolve.
 - **FAISS and pgvector wrappers** — integration adapters.
-- **`rank_certificate`** — distribution-free rank floors (the mathematics is frozen — it is
+- **`rank_certificate`** (surfaced by `tqp certify` to emit and `tqp verify` to re-check a
+  `certificate.json`) — distribution-free rank floors (the mathematics is frozen — it is
   a theorem — but the reporting surface / autotune fields may evolve in a minor release).
 - **`a2_probe` + `QualityMonitor` tangential stream** — (A2) consumer-metric probe and the
   streaming radial-drift statistic; thresholds and result fields may evolve.


### PR DESCRIPTION
Release blocker: README's tier summary predated the certification platform. Reconciled to `docs/api-stability.md` (named the source of truth):
- **Beta** now lists the rank certificate (`tqp certify`/`verify`), the (A2) probe + quality monitor, the `tqp index` lifecycle, and the runtime safe-fallback policy — not just ADCIndex/KVCache/wrappers.
- **Experimental** adds the plugin registry + conformance kit (eligible to promote).
- Both surfaces carry the 1.8.0 release-boundary note; `api-stability.md` surfaces `tqp verify` on the rank-certificate entry.

**PyPI long description = README** (`readme = "README.md"`), so PyPI is aligned by the same change — one fewer surface. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)