### PR TITLE
docs: promote the GloVe replay as the canonical 'trust this project' demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,16 @@ ce, seed = unpack(blob)                                 # self-describing: bits/
 
 ## Benchmarks
 
+> **🔬 Trust it in one command (CPU, seconds) — the canonical demo.** Don't take the numbers on faith; reproduce the headline retrieval result on **real public GloVe-100 data**, with the acceptance floor **gated** (it fails loudly if it regresses):
+>
+> ```bash
+> tqp replay embedding_glove_recall          # 1.8.0 / master; gates recall@10 >= 0.95, ratio >= 9.5
+> # or, from a clone on today's PyPI library:
+> python benchmarks/canonical_glove.py --small --out results.json
+> ```
+>
+> Full-dimension PCA + 3-bit TurboQuant feeding compressed-domain ADC search reaches **~9.6× compression at recall@10 ≈ 0.999** (12× oversample + exact rerank on the full 1.18M corpus); the hermetic `--small` subset runs in CI against the floors above, `--full` is the real corpus. Acceptance is **reranked recall — the metric retrieval consumes — never reconstruction cosine** (which reads ~0.98 here while single-pass ADC recall is only ~0.74). This is the "does it actually work" check, and it's honest about scope: `benchmarks/RESULTS_glove.md` documents where PCA *truncation* loses on GloVe (no Matryoshka structure) and the full-dimension recipe is used instead.
+
 Reproduce the full retrieval benchmark on **public data**, end-to-end, in a few minutes (CPU / Colab-friendly):
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ahb-sjsu/turboquant-pro/blob/master/notebooks/turboquant_benchmark.ipynb)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,16 @@ acceptance is measured on **that consumer's metric** — recall, a rank certific
 perplexity, an expert-set flip rate — **never reconstruction cosine**, which is
 repeatedly shown here to be blind or even anti-correlated with quality.
 
+## Prove it works first (one command, CPU, seconds)
+
+Before reading anything, reproduce the canonical retrieval result on **real public GloVe data**, with the recall floor **gated**:
+
+```bash
+tqp replay embedding_glove_recall     # gates recall@10 >= 0.95, compression >= 9.5x
+```
+
+~9.6× compression at recall@10 ≈ 0.999 (full corpus, rerank); the hermetic subset runs in CI. Acceptance is reranked recall, never reconstruction cosine. That is the whole thesis of this project in one command — everything below explains *why* it holds.
+
 ## New here? The 15-minute path
 
 ```


### PR DESCRIPTION
Release blocker from the 1.8.0 review. The strongest executable evidence — a **CI-gated, CPU, one-command** reproduction on **real public GloVe** — was buried under the notebooks. Foregrounded it:
- **README Benchmarks**: a 'Trust it in one command' callout leading with `tqp replay embedding_glove_recall` (gates recall@10 ≥ 0.95, ratio ≥ 9.5; ~9.6× @ recall 0.999 on the full corpus), acceptance = **reranked recall, never cosine**, and honest about the PCA-truncation caveat.
- **docs hub**: a 'Prove it works first' section above the 15-minute path.

No new claims — `embedding_glove_recall` already exists and is honest; this only raises its visibility. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)