### PR TITLE
release: 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,29 @@
 # Changelog
 
-## 1.8.0.dev0 (unreleased)
+## 1.8.0 (2026-07-17)
 
-> Master carries `version = "1.8.0.dev0"`: everything in this section is
-> **next-cycle / not yet released**. The newest released version is **1.7.0**
-> (git tag + GitHub Release + PyPI). Install from PyPI for released behavior;
-> install from `master` for the items below.
+> Released 2026-07-17 (git tag `v1.8.0` + GitHub Release + PyPI). This is the
+> **certification-platform** release: the `tqp` CLI, the persisted-index and
+> plugin certification lifecycle, and the portable Triton fused-decode kernels
+> land here. `pip install turboquant-pro` now gives you `tqp`.
 
 ### Added
+- **Certificate verification — `tqp verify`.** Re-check a `certificate.json`
+  emitted by `tqp certify`: schema / self-consistency always (offline), plus an
+  independent recompute when `--original`/`--reconstructed` are given (re-hash the
+  inputs against the recorded `sha256`, re-run the certification with the
+  certificate's own params, confirm the recorded floors reproduce within tolerance).
+  Exit 0 verified / 1 malformed-or-mismatch / 2 read error. `certify` writes
+  certificates; `verify` is how a third party trusts one.
+- **Hardware & plugin widening (P0–P5).** Out-of-tree quantizer plugin protocol +
+  entry-point registry + conformance kit; torch backend for reference paths;
+  in-tree incubator plugins `tqp-bnb` (NF4 / LLM.int8 + QLoRA interop),
+  `tqp-trtllm` (FP8 / NVFP4 KV), `tqp-gptq-awq`; `operator_trace` weight/KV
+  recommendation. **P5 — a portable Triton port of the M2/M4 fused-decode
+  kernels**: exact across Turing→Ampere→Ada→Hopper, its single-launch batched-page
+  variant beats the CuPy RawKernel **1.3–9.4×** and stays exact to ~1e-7 through
+  128k context (the CuPy RawKernel remains the CUDA reference/oracle). See
+  `docs/DESIGN_hardware_and_plugins.md` and `benchmarks/RESULTS_p5_triton.md`.
 - **Documentation hub + canonical guides (Phase 9).** [`docs/`](docs/) is now a
   front door: a rendered mermaid **architecture diagram** (artifact → trace → plan →
   compress → certify → replay → monitor, with the runtime-policy back-off loop), a

--- a/docs/CERTIFICATE_SPEC.md
+++ b/docs/CERTIFICATE_SPEC.md
@@ -17,7 +17,7 @@ compatibility promise for that artifact so downstream tooling can depend on it.
 {
   "schema": "turboquant-pro/rank-certificate",
   "schema_version": 1,
-  "tool_version": "1.8.0.dev0",
+  "tool_version": "1.8.0",
   "created_utc": "2026-07-16T18:04:11.686000+00:00",
   "inputs": {
     "original":      { "path": "emb.npy",   "shape": [1000, 768], "dtype": "float32", "sha256": "…" },

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -101,7 +101,7 @@ measurements serialize as `null` (never bare `NaN`), so it is always spec-valid.
 {
   "schema": "turboquant-pro/rank-certificate",   // format identity
   "schema_version": 1,                            // bumps only on breaking change
-  "tool_version": "1.8.0.dev0",
+  "tool_version": "1.8.0",
   "created_utc": "2026-07-17T…Z",
   "inputs": { "original": {"path","shape","dtype","sha256"},
               "reconstructed": {…} },             // provenance: what was certified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "turboquant-pro"
-version = "1.8.0.dev0"
+version = "1.8.0"
 description = "PCA-Matryoshka + TurboQuant compression for embeddings, LLM KV caches, pgvector, and NATS — up to 27x compression"
 readme = "README.md"
 license = {text = "MIT"}

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -262,4 +262,4 @@ try:
     )
 except Exception:
     pass
-__version__ = "1.8.0.dev0"
+__version__ = "1.8.0"


### PR DESCRIPTION
Cuts **1.8.0** — the certification-platform release.

- Version `1.8.0.dev0` → `1.8.0` (`pyproject.toml` + `turboquant_pro/__init__.py`).
- CHANGELOG 1.8.0 section flipped unreleased → **released (2026-07-17)**, with the certification-platform additions this cycle shipped: **`tqp verify`** and the **P0–P5 hardware/plugin widening** (plugin registry + conformance kit, `tqp-bnb`/`tqp-trtllm`/`tqp-gptq-awq` incubators, `operator_trace`, and the **portable P5 Triton port** — exact Turing→Hopper, batched beats the CuPy RawKernel 1.3–9.4× to 128k).
- Two format-spec example `tool_version` strings → `1.8.0`.

After this merges I'll tag `v1.8.0` and create the GitHub Release, which triggers `publish.yml` → PyPI. The 'not yet on PyPI' banners get flipped in a follow-up **once PyPI actually has 1.8.0** (so the repo never falsely claims it's live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)