### PR TITLE
repro: independent reproduction of embedding_glove_recall from PyPI 1.8.0

### DIFF
--- a/benchmarks/reproductions/embedding_glove_recall_1.8.0.md
+++ b/benchmarks/reproductions/embedding_glove_recall_1.8.0.md
@@ -1,0 +1,62 @@
+# Independent reproduction — `embedding_glove_recall` (v1.8.0, from PyPI)
+
+The canonical "trust this project" claim, reproduced from the **published 1.8.0
+package on PyPI** — not the development tree — in a clean, isolated virtualenv.
+The library under test is the shipped wheel (`site-packages`), installed with
+`pip`, so this exercises the artifact a user actually gets, not an editable
+`-e .` checkout.
+
+## Method
+
+```bash
+python -m venv venv && . venv/Scripts/activate
+pip install "turboquant-pro[yaml]==1.8.0"                 # from PyPI, not editable
+git clone --depth 1 --branch v1.8.0 \
+    https://github.com/ahb-sjsu/turboquant-pro
+cd turboquant-pro
+tqp replay embedding_glove_recall                          # gated replay
+```
+
+`tqp replay` executes the claim's command (`python benchmarks/canonical_glove.py
+--small`) and compares the normalized `results.json` against the floors declared
+in `claims.yaml` (`recall_at_10_rerank_min: 0.95`, `compression_ratio_min: 9.5`),
+exiting non-zero on any regression.
+
+## Environment
+
+| | |
+|---|---|
+| `turboquant-pro` | **1.8.0** (PyPI wheel, `site-packages` — not editable) |
+| Python | 3.12.2 |
+| numpy | 2.5.1 |
+| PyYAML | 6.0.3 |
+| Platform | Windows x86-64, CPU only |
+| Date | 2026-07-17 |
+
+## Result — reproduced
+
+```
+# tqp replay  claims=1  reproduced=1  regressed=0  error=0
+  [reproduced] embedding_glove_recall  (35.5 s, CPU)
+```
+
+From [`embedding_glove_recall_1.8.0.results.json`](embedding_glove_recall_1.8.0.results.json)
+(sha256 `28847b4186091a95a8e49c6248fa4db1f0d703caa2f8020f7629fedd3b22e2ff`):
+
+| metric | value | floor | pass |
+|---|---:|---:|:--:|
+| recall@10 (+rerank ×12) | **1.000** | ≥ 0.95 | ✅ |
+| compression ratio | **9.639×** | ≥ 9.5 | ✅ |
+| recall@10 (single-pass) | 0.788 | — | *(diagnostic)* |
+| mean cosine | 0.981 | — | *(diagnostic)* |
+
+The acceptance metric is **reranked recall** — the metric retrieval actually
+consumes. The single-pass recall (0.788) and reconstruction cosine (0.981) are
+labelled diagnostics: cosine reads ~0.98 while single-pass recall is far lower,
+exactly the divergence this project is built to expose. The floors are met, so
+the published package reproduces the headline retrieval claim on real public
+GloVe data on a stock CPU in about half a minute.
+
+*(Recipe: PCA-100 + 3-bit TurboQuant + compressed-domain ADC search, 12× oversample
++ exact rerank, on the hermetic bundled subset — n=2000, 100 queries. The full
+1.18M run is `tqp replay embedding_glove_recall` with `full_command`.)*

--- a/benchmarks/reproductions/embedding_glove_recall_1.8.0.results.json
+++ b/benchmarks/reproductions/embedding_glove_recall_1.8.0.results.json
@@ -1,0 +1,15 @@
+{
+  "claim": "embedding_glove_recall",
+  "dataset": "glove-100-angular (tiny bundled subset)",
+  "n": 2000,
+  "dim": 100,
+  "out_dim": 100,
+  "bits": 3,
+  "recipe": "PCA-100 + TQ3 + ADC, rerank x12",
+  "compression_ratio": 9.639,
+  "recall_at_10": 0.788,
+  "recall_at_10_rerank": 1.0,
+  "n_queries": 100,
+  "oversample": 12,
+  "secondary_diagnostic_mean_cosine": 0.981283
+}


### PR DESCRIPTION
One independent reproduction artifact, as requested. The canonical trust claim reproduced from the **published 1.8.0 wheel on PyPI** (`pip install turboquant-pro[yaml]==1.8.0`, `site-packages` — *not* an editable `-e .` checkout), in a clean venv against a fresh `v1.8.0` clone:

```
# tqp replay  claims=1  reproduced=1  regressed=0  error=0
  [reproduced] embedding_glove_recall  (35.5 s, CPU)
```

| metric | value | floor | pass |
|---|---:|---:|:--:|
| recall@10 (+rerank) | **1.000** | ≥ 0.95 | ✅ |
| compression | **9.639×** | ≥ 9.5 | ✅ |

Commits the `results.json` (sha256 pinned) + a method/environment writeup under `benchmarks/reproductions/`. This exercises the artifact a user actually installs, not the dev tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)