### PR TITLE
release: 1.8.1 — refresh PyPI long description (metadata-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.8.1 (2026-07-17)
+
+Patch release — **release metadata only, no API or behavior change** from 1.8.0.
+
+### Fixed
+- **PyPI long description.** The 1.8.0 sdist/wheel were built from the `v1.8.0`
+  tag *before* the "released" documentation banners merged, so the PyPI project
+  page rendered a stale description (still reading "Current package: 1.7.0" and
+  "the `tqp` CLI … not yet on PyPI"). 1.8.1 rebuilds from the corrected README so
+  the PyPI page, the repository README, and the release history all agree. First
+  independent reproduction of `embedding_glove_recall` from the published wheel is
+  recorded in `benchmarks/reproductions/`.
+
 ## 1.8.0 (2026-07-17)
 
 > Released 2026-07-17 (git tag `v1.8.0` + GitHub Release + PyPI). This is the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "turboquant-pro"
-version = "1.8.0"
+version = "1.8.1"
 description = "PCA-Matryoshka + TurboQuant compression for embeddings, LLM KV caches, pgvector, and NATS — up to 27x compression"
 readme = "README.md"
 license = {text = "MIT"}

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -262,4 +262,4 @@ try:
     )
 except Exception:
     pass
-__version__ = "1.8.0"
+__version__ = "1.8.1"


### PR DESCRIPTION
Fixes the visible metadata bug from the review. The 1.8.0 wheel/sdist were built from `v1.8.0` **before** the 'released' banners merged (#152), so PyPI renders a stale description — 'Current package: 1.7.0', 'not yet on PyPI'. PyPI descriptions are **immutable per release**, so the only fix is a new upload.

1.8.1 is **metadata-only**: version bump (`pyproject` + `__init__`) + CHANGELOG; rebuilds from the corrected README so the PyPI page, README, and release history agree. No API/behavior change from 1.8.0.

After merge I'll tag + release `v1.8.1` (token path, proven) → PyPI, and verify the rendered description is fixed. Trusted Publishing / provenance is a separate follow-up (needs a one-time PyPI-side config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)