### PR TITLE
ci: PyPI Trusted Publishing (OIDC) + PEP 740 provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,20 @@
 name: publish
 
-# Publish to PyPI when a GitHub Release is published (or on manual dispatch).
-# Uses the PYPI_API_TOKEN repository secret.
+# Publish to PyPI when a GitHub Release is published (or on manual dispatch),
+# via PyPI Trusted Publishing (OIDC) with PEP 740 provenance attestations —
+# no long-lived API token.
+#
+# ── ONE-TIME PyPI SETUP (required before the next release) ───────────────────
+# Add a Trusted Publisher for this project at:
+#   https://pypi.org/manage/project/turboquant-pro/settings/publishing/
+#     PyPI project name : turboquant-pro
+#     Owner             : ahb-sjsu
+#     Repository name    : turboquant-pro
+#     Workflow filename  : publish.yml
+#     Environment        : (leave blank)
+# Once that exists, no PYPI_API_TOKEN secret is needed; the OIDC exchange below
+# authenticates the upload and PyPI records signed provenance for each artifact.
+# (The secret can be revoked after the first successful trusted-publishing run.)
 on:
   release:
     types: [published]
@@ -10,6 +23,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # mint the OIDC token Trusted Publishing exchanges with PyPI
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,10 +39,13 @@ jobs:
         run: |
           python -m pip install --upgrade twine
           python -m twine check dist/*
-      - name: Publish to PyPI
+      - name: Publish to PyPI (Trusted Publishing + provenance)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          # No `password:` → the action uses OIDC Trusted Publishing. With no
+          # explicit password, `attestations: true` is honored and PEP 740
+          # provenance is generated and uploaded alongside the artifacts.
+          attestations: true
           # Idempotent: re-cutting a Release for an already-published version
-          # (e.g. backfilling old GitHub Releases) is a no-op, not a 400 error.
+          # is a no-op, not a 400 error.
           skip-existing: true


### PR DESCRIPTION
Task #2 — the supply-chain trust upgrade. Replaces the API-token upload with **OIDC Trusted Publishing** and enables **PEP 740 provenance attestations** (previously ignored because the explicit token disabled trusted publishing, per the warnings on the 1.8.0/1.8.1 runs).

- `permissions: id-token: write` — mints the OIDC token PyPI exchanges
- drops `password:` — the action uses Trusted Publishing when no password is set
- `attestations: true` — signed provenance uploaded alongside each artifact
- no long-lived `PYPI_API_TOKEN` in the supply chain

## ⚠️ Requires a one-time PyPI config BEFORE the next release
Add a Trusted Publisher at **https://pypi.org/manage/project/turboquant-pro/settings/publishing/** — Owner `ahb-sjsu`, Repo `turboquant-pro`, Workflow `publish.yml`, Environment blank. Until that exists, a release would fail auth. **1.8.0 and 1.8.1 are already published via the token path;** this takes effect from the next version. Safe to merge now (only affects future publishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)