### PR TITLE
feat: experimental key calibration API + the honest result (does not beat the default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ On LongBench (**Llama-2-7B-chat**) this recovers `qasper` from 14.38 (uniform 4-
 
 > ⚠️ **This result is Llama-family-specific.** Symmetric `key_nf4` is the best naive codebook on MHA/low-GQA models but **collapses on high-ratio-GQA models** (Qwen2.5-7B). For a single codebook that is robust everywhere, prefer **`key_nf4_asym`** / `TurboQuantKVCache.robust()` — see the next section.
 
+> **Optional online calibration (experimental, honest scope).** `calibrate_key_quantizer(sample_keys)` fits a per-channel data-fit (Lloyd-Max) key codebook from a calibration set. In our measurements it **lowers reconstruction error but does *not* beat the calibration-free asym-NF4 default on the attention metric (softmax-KL)** — reconstruction is not the target, again ([`benchmarks/RESULTS_calibration.md`](benchmarks/RESULTS_calibration.md)). It's provided so you can measure it on *your* task; the zero-calibration default stays recommended.
+
 #### Recommended: asymmetric NF4 — one codebook for every architecture (v1.4.0)
 Symmetric `key_nf4` is the best naive codebook on MHA / low-GQA models but **silently collapses on high-ratio-GQA models** (Qwen2.5-7B: qasper 43.8 → 4.7, WikiText-2 ppl 7.46 → 74.7, degenerate repetition) — NF4 is zero-centred while KV keys carry a per-channel DC offset, so it wastes half its codes. **`key_nf4_asym=True`** adds a per-channel zero-point: it ties NF4 where NF4 works *and* rescues the collapse where it doesn't (Qwen → **41.9 qasper / 7.50 ppl**), at no extra bit cost. Use the `robust()` factory:
 

--- a/benchmarks/RESULTS_calibration.md
+++ b/benchmarks/RESULTS_calibration.md
@@ -1,0 +1,62 @@
+# Opt-in online key calibration — an honest negative on the consumer metric
+
+**Headline: lightweight online calibration does *not* beat the calibration-free
+default on the metric attention consumes.** It lowers raw reconstruction error,
+but softmax-KL — the thing the model actually uses — gets *worse*. This is the
+project's own thesis (reconstruction error is not the target) re-confirmed
+against a feature we hoped would help. The API ships **experimental / opt-in**;
+the recommended key path remains calibration-free asym-NF4 + 2% outliers.
+
+## What was tried
+
+`calibrate_key_quantizer` / `PerChannelKV.calibrate` fit a per-(head, channel)
+**Lloyd-Max (MSE-optimal)** codebook from a representative sample of real keys and
+reuse it — the data-fit idea behind KVQuant's offline calibration, made
+lightweight (Lloyd over a sample, optional importance weights).
+
+## Result — measured, not hoped
+
+Acceptance metric is **softmax-KL** of `q·Kᵀ` vs fp16 (the attention consumer),
+matched at 4-bit + 2% outliers, on a realistic post-RoPE-like regime
+(per-channel DC offset + heavy Student-t(3) tails), on a held-out block.
+
+**Single favorable seed (what looked like a win):**
+
+| key codebook | key \|err\| | softmax-KL |
+|---|---:|---:|
+| asym-NF4 (calibration-free default) | 0.238 | 0.365 |
+| calibrated — equal-mass quantiles | 0.146 | 1.698 |
+| calibrated — Lloyd-Max | **0.116** | 0.288 |
+
+**Across seeds (the truth):** repeating over independent distribution / query /
+test draws, the Lloyd-calibrated codebook's softmax-KL ratio to the
+calibration-free default is **mean 1.29, median 1.26 — it lost in 6/6 trials**
+(≈29% *worse* attention fidelity). The single-seed 0.288 above was
+query-seed luck.
+
+## Two honest findings
+
+1. **Reconstruction ≠ attention, again.** Lloyd calibration reliably *lowers key
+   reconstruction error* (it minimizes MSE by construction), yet reliably
+   *raises* softmax-KL. Optimizing the marginal per-channel codebook discards the
+   explicit DC-offset / zero-point modeling that makes asym-NF4 well-matched to
+   post-RoPE keys — so the reconstruction gets closer while the attention
+   distribution gets further. This is exactly the failure mode the project was
+   built to expose.
+2. **Equal-mass quantile calibration is worse still** (KL 1.70). Whatever the
+   right objective is, it is neither "equalize mass" nor "minimize marginal MSE".
+
+## Scope and what would settle it
+
+- This is a **synthetic proxy** (softmax-KL on a controlled distribution), not a
+  task score. It does **not** prove the option is useless on *real* data: KVQuant
+  reports a ~0.24 qasper gain from a **sensitivity-weighted (Fisher) K-means**
+  codebook — a stronger objective than plain Lloyd, on real key/query
+  correlations. Whether that closes the gap here is a real-model question:
+  `benchmarks/kv_quant_shootout.py` / `benchmarks/kvquant_matrix/` with a
+  calibrated key quantizer, on a GPU box.
+- So the API is provided **experimental**, for users who want to try a data-fit
+  codebook and measure it on *their* task — with the honest expectation set here
+  that a lightweight Lloyd codebook did not beat the calibration-free default on
+  our attention proxy. Closing the last fraction likely needs Fisher-weighting
+  against the real query distribution, not a lighter method.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -45,6 +45,11 @@ be removed without notice, may require optional dependencies or specific hardwar
   at the next stability review; it is held at Experimental for this release cycle
   while the protocol settles. Out-of-tree plugins themselves enter at this tier
   and promote per the design doc.
+- **Online key calibration** (`calibrate_key_quantizer` / `PerChannelKV.calibrate`)
+  — opt-in data-fit Lloyd-Max key codebook. Lowers reconstruction error but, on
+  our attention proxy, does **not** beat the calibration-free default on
+  softmax-KL (`benchmarks/RESULTS_calibration.md`); provided for users to measure
+  on their own task. Experimental; the zero-calibration default stays recommended.
 - **CUDA fused decode kernel** — requires a compatible GPU + build toolchain.
 - **vLLM manager** (`TurboQuantKVManager`) — inference-server integration.
 - **Model-weight compressor** — weight pruning/quantization path.

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,81 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""Opt-in online key calibration (`PerChannelKV.calibrate` / `calibrate_key_quantizer`).
+
+Scope note (see benchmarks/RESULTS_calibration.md): the Lloyd-Max codebook
+reliably lowers *reconstruction* error but does **not** beat the calibration-free
+default on the attention consumer metric (softmax-KL) — the API is experimental.
+These tests assert only the robust facts: calibration lowers reconstruction
+error, the container round-trips, and the zero-calibration default is untouched.
+They deliberately do NOT assert a softmax-KL win, which is not robust.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from turboquant_pro import PerChannelKV, calibrate_key_quantizer
+
+H, D = 4, 32
+
+
+def _keys(S, seed):
+    """Realistic post-RoPE-like keys: per-channel DC offset + heavy tails."""
+    r = np.random.default_rng(seed)
+    dc = np.random.default_rng(0).uniform(-6, 6, (H, D)).astype(np.float32)
+    sc = np.random.default_rng(1).uniform(0.2, 1.5, (H, D)).astype(np.float32)
+    t = r.standard_t(3, (1, H, S, D)).astype(np.float32)
+    return (dc[None, :, None, :] + sc[None, :, None, :] * t).astype(np.float32)
+
+
+def _recon_err(kq, test):
+    return float(np.abs(kq.decompress(kq.compress(test))[0] - test[0]).mean())
+
+
+def test_calibration_lowers_reconstruction_error():
+    # Lloyd-Max minimizes quantization MSE, so calibrated reconstruction is
+    # reliably closer than the fixed NF4 grid (this is robust; the attention-KL
+    # win is not -- see RESULTS_calibration.md).
+    cal, test = _keys(1500, 1), _keys(256, 2)
+    nf4 = PerChannelKV(head_dim=D, n_heads=H, nf4_asym=True, outlier_frac=0.02)
+    calq = calibrate_key_quantizer(
+        cal, bits=4, outlier_frac=0.02, head_dim=D, n_heads=H, iters=10
+    )
+    assert _recon_err(calq, test) < _recon_err(nf4, test)
+
+
+def test_default_path_untouched():
+    # calibration is strictly opt-in; a plain quantizer is never calibrated
+    q = PerChannelKV(head_dim=D, n_heads=H)
+    assert q.calibrated_levels is None
+    x = _keys(32, 5)
+    assert q.decompress(q.compress(x)).shape == x.shape
+
+
+def test_calibrated_container_roundtrips():
+    cal, test = _keys(1200, 1), _keys(64, 2)
+    kq = calibrate_key_quantizer(cal, bits=4, head_dim=D, n_heads=H, iters=8)
+    assert kq.calibrated_levels.shape == (H, D, 16)
+    out = kq.decompress(kq.compress(test, packed=True))
+    assert out.shape == test.shape
+    assert np.isfinite(out).all()
+
+
+def test_shared_codebook_from_2d_samples():
+    # (N, D) samples -> one codebook shared across heads, broadcasts on compress
+    cal2d = _keys(2000, 1)[0].transpose(1, 0, 2).reshape(-1, D)  # (H*S, D)
+    kq = calibrate_key_quantizer(cal2d, bits=4, head_dim=D, n_heads=H, iters=8)
+    assert kq.calibrated_levels.shape == (D, 16)  # shared across heads
+    test = _keys(64, 2)
+    assert kq.decompress(kq.compress(test)).shape == test.shape
+
+
+def test_weighted_calibration_runs():
+    cal = _keys(1200, 1)
+    w = np.abs(np.random.default_rng(3).standard_normal(cal.shape[0] * cal.shape[2]))
+    kq = calibrate_key_quantizer(
+        cal, bits=4, outlier_frac=0.02, head_dim=D, n_heads=H, weights=w, iters=8
+    )
+    assert kq.calibrated_levels.shape == (H, D, 16)

--- a/turboquant_pro/__init__.py
+++ b/turboquant_pro/__init__.py
@@ -47,6 +47,7 @@ from .behavioral_agreement import (
     noise_floor,
 )
 from .cache_adapter import CompressedEmbeddingCache, InMemoryCacheBackend
+from .calibration import calibrate_key_quantizer
 from .core import CompressedKV, TurboQuantKV, TurboQuantKVCache
 from .export import (
     GenericExporter,
@@ -151,6 +152,7 @@ __all__ = [
     "torch_decode",
     "CompressedPerChannelKV",
     "PerChannelKV",
+    "calibrate_key_quantizer",
     "PluginSpec",
     "available_plugins",
     "create_quantizer",

--- a/turboquant_pro/calibration.py
+++ b/turboquant_pro/calibration.py
@@ -1,0 +1,74 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""Opt-in online calibration for KV-cache keys — **experimental**.
+
+The **zero-calibration** path (calibration-free asymmetric NF4 + 2% outliers)
+stays the default and the **recommended** choice — nothing here changes it.
+
+:func:`calibrate_key_quantizer` fits a per-(head, channel) **Lloyd-Max**
+(MSE-optimal) key codebook **once** from a representative set of real key
+activations and reuses it, instead of the fixed NF4 grid — the data-fit idea
+behind KVQuant's offline codebook, made lightweight.
+
+**Honest caveat** (``benchmarks/RESULTS_calibration.md``): on a controlled
+attention proxy this **lowers key reconstruction error but does *not* beat the
+calibration-free default on softmax-KL** — the metric attention actually
+consumes. Optimizing the marginal per-channel codebook discards the DC-offset
+modeling that makes asym-NF4 well-matched to post-RoPE keys. It is provided so
+users can try a data-fit codebook and measure it on *their* task; whether a
+stronger, Fisher-weighted objective closes the real qasper gap is left open.
+Composes with `outlier_frac`, self-describing (levels travel in the container),
+and — like all `nuq` keys — decodes via decompress-then-attend, not the fused
+kernel.
+
+Example::
+
+    from turboquant_pro import calibrate_key_quantizer
+
+    # `cal` = a modest sample of real post-RoPE keys, shape (B, H, S, D)
+    kq = calibrate_key_quantizer(cal, bits=4, outlier_frac=0.02)
+    c  = kq.compress(new_keys)          # data-fit codebook, reused
+    k  = kq.decompress(c)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .per_channel_kv import PerChannelKV
+
+__all__ = ["calibrate_key_quantizer"]
+
+
+def calibrate_key_quantizer(
+    samples: np.ndarray,
+    *,
+    bits: int = 4,
+    outlier_frac: float = 0.02,
+    weights: np.ndarray | None = None,
+    iters: int = 20,
+    **kwargs,
+) -> PerChannelKV:
+    """Build a :class:`~turboquant_pro.per_channel_kv.PerChannelKV` with a
+    per-channel codebook calibrated from ``samples``.
+
+    Thin wrapper over ``PerChannelKV(...).calibrate(samples)``.
+
+    Args:
+        samples: real key activations — ``(N, D)``, ``(N, H, D)``, or
+            ``(B, H, S, D)``. Pooled over every axis except channel ``D`` (head
+            ``H`` kept when present).
+        bits: code width (default 4).
+        outlier_frac: dense-sparse fp16 tail kept per channel (default 0.02 — the
+            measured sweet spot; set 0.0 to disable).
+        weights: optional per-token importance (a light Fisher/sensitivity
+            surrogate); uniform when omitted.
+        **kwargs: forwarded to ``PerChannelKV`` (e.g. ``head_dim``, ``n_heads``).
+
+    Returns:
+        A calibrated ``PerChannelKV`` ready to ``compress`` / ``decompress``.
+    """
+    q = PerChannelKV(bits=bits, outlier_frac=outlier_frac, **kwargs)
+    return q.calibrate(samples, weights=weights, iters=iters)

--- a/turboquant_pro/per_channel_kv.py
+++ b/turboquant_pro/per_channel_kv.py
@@ -219,6 +219,9 @@ class PerChannelKV:
         self.nf4_asym = nf4_asym
         self.outlier_frac = outlier_frac
         self.zero_point = zero_point
+        # opt-in data-fit codebook from PerChannelKV.calibrate(); None = the
+        # zero-calibration default (per-block quantiles / NF4). Shape (H,D,L) or (D,L).
+        self.calibrated_levels: np.ndarray | None = None
         self.rope_theta = rope_theta
         self.k_bias = k_bias
         self.qmax = 2**bits - 1
@@ -352,6 +355,22 @@ class PerChannelKV:
             amax = np.maximum(np.abs(x).max(axis=2), 1e-8)  # (B,H,D)
             cent = (amax[..., None] * _NF4[None, None, None, :]).astype(np.float32)
             nf4_scale = amax.astype(np.float32)
+        elif self.calibrated_levels is not None:
+            # calibrated NUQ: a per-channel codebook fit ONCE from a representative
+            # set (PerChannelKV.calibrate) and reused for every block, instead of
+            # re-fitting per-block quantiles -- better level estimates and stable
+            # codes (the KVQuant-style data-fit path, opt-in).
+            cal = self.calibrated_levels
+            lvl = cal.shape[-1]
+            if cal.ndim == 3:  # (H, D, L) -- per head + channel
+                if cal.shape[0] != H:
+                    raise ValueError(
+                        f"calibrated for {cal.shape[0]} heads but input has {H}"
+                    )
+                cent = np.broadcast_to(cal[None], (B, H, D, lvl))
+            else:  # (D, L) -- shared across heads
+                cent = np.broadcast_to(cal[None, None], (B, H, D, lvl))
+            cent = np.ascontiguousarray(cent, dtype=np.float32)
         else:
             qs = np.linspace(0.0, 1.0, 2**self.bits, dtype=np.float32)
             cent = np.moveaxis(np.quantile(x, qs, axis=2), 0, -1).astype(np.float32)
@@ -380,6 +399,100 @@ class PerChannelKV:
             rope_theta=zp_theta,
             position_start=position_start,
         )
+
+    def calibrate(self, samples, weights=None, iters: int = 20) -> PerChannelKV:
+        """**Experimental.** Fit a per-channel Lloyd-Max (MSE-optimal) key
+        codebook from a representative calibration set, once, and reuse it for
+        every future ``compress`` -- an opt-in, data-fit alternative to the
+        calibration-free default (which stays recommended and unchanged).
+
+        **Honest caveat** (``benchmarks/RESULTS_calibration.md``): this lowers
+        *key reconstruction error*, but was measured to **not** beat the
+        calibration-free asym-NF4 default on the attention consumer metric
+        (softmax-KL) -- optimizing the marginal per-channel codebook discards the
+        DC-offset / zero-point modeling that attention on post-RoPE keys relies
+        on, so reconstruction gets closer while the attention distribution gets
+        further (the project's reconstruction-is-not-the-target thesis, again).
+        Provided so users can try a data-fit codebook and measure it on *their*
+        task/data; whether a stronger, Fisher-weighted objective closes the real
+        qasper gap is a real-model question left open.
+
+        The levels minimize expected quantization MSE per channel, initialized
+        from quantiles and refined by Lloyd's algorithm. (Equal-mass *quantile*
+        levels were measured worse still on the consumer metric, so this uses
+        Lloyd, not quantiles.)
+
+        ``samples`` -- real key activations: ``(N, D)``, ``(N, H, D)``, or
+        ``(B, H, S, D)``. Levels are pooled over every axis except channel ``D``
+        (and head ``H`` is kept when present -> a per-(head, channel) codebook).
+        ``weights`` -- optional per-token importance (a light Fisher/sensitivity
+        surrogate) folded into the Lloyd centroid means; uniform when omitted.
+        ``iters`` -- Lloyd refinement iterations (default 20).
+
+        Returns ``self`` (enables ``nuq``; the calibrated levels travel in each
+        compressed container, so ``decompress`` needs no extra state). Composes
+        with ``outlier_frac``; like all ``nuq`` keys it decodes via
+        decompress-then-attend rather than the fused NF4/uniform kernel.
+        """
+        x = np.asarray(samples, dtype=np.float32)
+        levn = 2**self.bits
+        qs = np.linspace(0.0, 1.0, levn, dtype=np.float64)
+        if x.ndim == 4:  # (B,H,S,D) -> per (head, channel)
+            B, H, S, D = x.shape
+            pooled = np.moveaxis(x, (1, 3), (0, 1)).reshape(H, D, B * S)
+            wv = (
+                None
+                if weights is None
+                else np.broadcast_to(
+                    np.asarray(weights, np.float64).reshape(-1), (B * S,)
+                )
+            )
+        elif x.ndim == 3:  # (N,H,D) -> per (head, channel)
+            _, H, D = x.shape
+            pooled = np.moveaxis(x, 0, -1)  # (H, D, N)
+            wv = (
+                None if weights is None else np.asarray(weights, np.float64).reshape(-1)
+            )
+        elif x.ndim == 2:  # (N,D) -> shared across heads
+            pooled = x.T[None]  # (1, D, N)
+            wv = (
+                None if weights is None else np.asarray(weights, np.float64).reshape(-1)
+            )
+        else:
+            raise ValueError(
+                f"calibrate expects (N,D)/(N,H,D)/(B,H,S,D), got {x.shape}"
+            )
+
+        hc, dc, n = pooled.shape
+        p2 = pooled.reshape(-1, n)  # (C, N)
+        w2 = None if wv is None else np.broadcast_to(wv, (n,))[None, :]
+        lv = np.quantile(p2, qs, axis=-1).T.astype(np.float64)  # (C, L) -- init
+        chunk = 64  # channels per step: bounds the (chunk, L, N) assignment tensor
+        for _ in range(iters):
+            for a in range(0, p2.shape[0], chunk):
+                pc = p2[a : a + chunk]  # (c, N)
+                lc = lv[a : a + chunk]  # (c, L)
+                idx = np.abs(pc[:, None, :] - lc[:, :, None]).argmin(1)  # (c, N)
+                wc = None if w2 is None else w2  # (1, N) broadcasts over c
+                newl = lc.copy()
+                for level in range(levn):
+                    m = idx == level
+                    if wc is None:
+                        cnt, s = m.sum(1), (pc * m).sum(1)
+                    else:
+                        cnt, s = (m * wc).sum(1), (pc * m * wc).sum(1)
+                    newl[:, level] = np.where(
+                        cnt > 0, s / np.maximum(cnt, 1e-12), lc[:, level]
+                    )
+                lv[a : a + chunk] = np.sort(newl, axis=1)
+
+        levels = lv.reshape(hc, dc, levn)
+        if x.ndim == 2:
+            levels = levels[0]  # (D, L)
+        self.calibrated_levels = np.ascontiguousarray(levels, dtype=np.float32)
+        self.nuq = True
+        self.nf4 = False
+        return self
 
     def decompress(self, c: CompressedPerChannelKV) -> np.ndarray:
         B, H, S, D = c.shape


### PR DESCRIPTION
The reviewer's #3 (online calibration to close the last qasper fraction). I built it, measured it rigorously, and the result is a **principled negative** — reported honestly rather than shipped as a win.

**API** (opt-in, default unchanged): `calibrate_key_quantizer(sample_keys)` / `PerChannelKV.calibrate` fit a per-(head,channel) **Lloyd-Max** codebook once and reuse it.

**Finding** (`benchmarks/RESULTS_calibration.md`): it **lowers reconstruction error but does *not* beat calibration-free asym-NF4 on softmax-KL** — the attention consumer metric. Across independent seeds the KL ratio calib/NF4 is **mean 1.29, lost 6/6**; an early single-seed 'win' was query-seed luck. Equal-mass quantile calibration is worse still. Optimizing the marginal codebook discards the DC-offset modeling attention relies on — **reconstruction is not the target, again**.

Ships **Experimental** with the caveat front-and-center (docstrings, api-stability, README, results doc). Tests assert only robust facts (reconstruction improves, round-trips, default untouched) — **not** a KL win. Whether a Fisher-weighted objective closes the *real* qasper gap is a model-run question left open. 5 tests, ruff+black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)