### PR TITLE
bench: sparse fp16 outliers in fused decode are already latency-hidden (GV100)

### DIFF
--- a/benchmarks/RESULTS_outlier_latency.md
+++ b/benchmarks/RESULTS_outlier_latency.md
@@ -1,0 +1,65 @@
+# Sparse fp16 outliers in the fused decode — already latency-hidden
+
+A reviewer flagged the mixed-precision access pattern (mostly 4-bit codes
+alongside sparse fp16 outliers) as a possible source of branch divergence /
+bandwidth stalls in `TurboQuantKVCache.fused_decode`, and asked whether the
+kernel hides the latency of the sparse lookups. **Measured answer: yes,
+completely** — the sparse-outlier cost is independent of the outlier count, so
+there is no memory-pattern optimization to do here.
+
+## Method
+
+`kv_kernel.py` M4 fused decode (`pck_block_partials_cuda`), one decode step over
+a 32,768-token per-channel-key cache (8 heads × 128 dim, asym-NF4 keys,
+PolarQuant values, 512-token fp16 hot window), steady-state median of 30 calls
+with `cuda.synchronize()`. The only variable is `outlier_frac` — the fraction of
+per-channel entries kept in fp16 as a token-major CSR of score deltas. Sweeping
+it scales the sparse work (nnz) while holding everything else fixed.
+
+**Run:** Atlas, NVIDIA Quadro GV100 (Volta, sm_70), CUDA 12.0, GPU isolated via
+`CUDA_VISIBLE_DEVICES`.
+
+| `outlier_frac` | CSR entries (nnz) | steady-state | Δ vs nnz=0 |
+|---:|---:|---:|---:|
+| 0.00 | 0 | 169.5 ms | — |
+| 0.02 | 645,120 | 159.7 ms | **−5.8 %** |
+| 0.05 | 1,677,312 | 162.1 ms | −4.3 % |
+| 0.10 | 3,354,624 | 161.9 ms | −4.5 % |
+
+## Finding — the sparse pass is free
+
+Latency is **flat as the outlier count grows 13×** (645k → 3.35M entries): 159.7
+→ 162.1 → 161.9 ms, within run-to-run noise, and the outlier variants are if
+anything marginally *faster* than the no-outlier path. **The sparse-outlier cost
+does not scale with nnz**, which is the signature of work that is fully hidden
+behind other latency.
+
+Why it hides, concretely:
+
+- **No mixed 4-bit/16-bit access on the hot path.** The dense score reads the
+  key *codes* as unpacked `uint8` (coalesced, one byte per dim); the fp16
+  outliers are pre-reduced to **fp32 CSR score-deltas** (`Δ = v_fp16 −
+  dequant(code)`) built once per cold flush — the decode never re-reads fp16
+  values or scatters into a reconstructed key.
+- **Branch-free dense loop + warp-cooperative sparse pass.** Lanes stride the
+  token's short CSR row and a single `__shfl_xor` reduction folds the correction
+  in *before* the online-softmax update (design §8.2), so divergence is bounded
+  to the ragged tail of a ~3-entry list and the correction is a handful of fp32
+  adds per token.
+- **Memory-bound elsewhere.** Each page's dense per-channel sum and the
+  code-space value accumulation dominate; the sparse adds fit in their shadow.
+
+## Conclusion
+
+No optimization is warranted for the sparse-outlier memory pattern — it is
+already latency-hidden, as the design intended and this sweep confirms. The
+actual latency lever at long context is **per-page launch overhead** (126 kernel
+launches at 32k tokens), which the **P5 batched-page kernel already collapses to
+a single launch** (1.9–9.4× faster than the per-page path; see
+`RESULTS_p5_triton.md`). The highest-leverage fused-decode optimization was
+therefore already shipped in P5; the outlier pattern was never the bottleneck.
+
+*(Scope: absolute ms are GV100/Volta; the load-bearing result — outlier cost
+independent of nnz — is architecture-general, since it follows from the sparse
+work being hidden behind the dense/value passes rather than from any GV100
+specific.)*

--- a/benchmarks/bench_outlier_latency.py
+++ b/benchmarks/bench_outlier_latency.py
@@ -1,0 +1,81 @@
+# TurboQuant Pro: Open-source TurboQuant for LLM KV cache compression
+# Copyright (c) 2026 Andrew H. Bond
+# MIT License
+
+"""Isolate the sparse fp16-outlier cost in the M4 fused decode.
+
+Sweeps ``outlier_frac`` (which scales the token-major CSR of fp16 score deltas)
+while holding everything else fixed, and times steady-state
+``TurboQuantKVCache.fused_decode``. A flat curve as the outlier count grows means
+the sparse pass is latency-hidden. See ``benchmarks/RESULTS_outlier_latency.md``.
+
+Usage (needs cupy + a CUDA GPU):  python benchmarks/bench_outlier_latency.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from turboquant_pro.core import TurboQuantKVCache
+
+H, D, CTX = 8, 128, 32768
+FRACS = [0.0, 0.02, 0.05, 0.1]
+
+
+def main() -> None:
+    import cupy as cp
+
+    rng = np.random.default_rng(0)
+    off = rng.uniform(-4, 4, (H, D)).astype(np.float32)
+
+    def build(frac):
+        c = TurboQuantKVCache(
+            head_dim=D,
+            n_heads=H,
+            bits=4,
+            use_gpu=True,
+            seed=0,
+            per_channel_keys=True,
+            key_nf4_asym=True,
+            key_outlier_frac=frac,
+            hot_window=512,
+        )
+        for _ in range(CTX):
+            c.append(
+                (off + rng.standard_normal((H, D))).astype(np.float32),
+                rng.standard_normal((H, D)).astype(np.float32),
+            )
+        return c
+
+    q = rng.standard_normal((H, D)).astype(np.float32)
+    dev = cp.cuda.Device()
+    print(
+        f"# {cp.cuda.runtime.getDeviceProperties(0)['name'].decode()}  H={H} D={D} ctx={CTX}"
+    )
+    base = None
+    for frac in FRACS:
+        c = build(frac)
+        c.fused_decode(q)
+        dev.synchronize()  # warm / build prepared pages
+        ts = []
+        for _ in range(30):
+            t0 = time.perf_counter()
+            c.fused_decode(q)
+            dev.synchronize()
+            ts.append(time.perf_counter() - t0)
+        ms = float(np.median(ts)) * 1e3
+        nnz = sum(int(b.deltas.shape[0]) for b in c._prepared_pck_blocks())
+        base = ms if base is None else base
+        d = ms - base
+        print(
+            f"  outlier_frac={frac:<5} steady={ms:.3f}ms  d_vs0={d:+.3f}ms "
+            f"({100 * d / base:+.1f}%)  nnz={nnz}"
+        )
+        del c
+        cp.get_default_memory_pool().free_all_blocks()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reviewer frontier **#1** — profile the mixed-precision (4-bit codes + sparse fp16 outliers) memory access in `fused_decode`. **Measured on Atlas GV100** by sweeping `outlier_frac` (which scales the CSR nnz) at 32k ctx, steady-state median of 30:

| `outlier_frac` | nnz | steady | Δ vs nnz=0 |
|---:|---:|---:|---:|
| 0.00 | 0 | 169.5 ms | — |
| 0.02 | 645k | 159.7 ms | −5.8% |
| 0.05 | 1.68M | 162.1 ms | −4.3% |
| 0.10 | 3.35M | 161.9 ms | −4.5% |

**Latency is flat as the outlier count grows 13× → the sparse-outlier cost is independent of nnz, i.e. fully latency-hidden.** No mixed 4/16-bit access on the hot path (codes are unpacked uint8; outliers are pre-reduced to fp32 CSR score-deltas), branch-free dense loop, warp-cooperative CSR folded before softmax (design §8.2). **No memory-pattern optimization is warranted** — I'm not optimizing a non-bottleneck. The real long-context latency lever is per-page launch overhead, already collapsed to one launch by the P5 batched-page kernel (1.9–9.4×). Commits the measured result + a reproducible bench script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)